### PR TITLE
Fix render NPE

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
@@ -18,7 +18,6 @@ import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
-import shedar.mods.ic2.nuclearcontrol.panel.ScreenManager;
 
 @SideOnly(Side.CLIENT)
 public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
@@ -121,7 +120,10 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
 				TileEntityAdvancedInfoPanelExtender advancedExtender = (TileEntityAdvancedInfoPanelExtender) tileEntity;
 				boolean wasRendered = false;
 
-				if (IC2NuclearControl.instance.screenManager != null) {
+				if (IC2NuclearControl.instance.screenManager == null || IC2NuclearControl.instance.screenManager.getScreens().get(
+					IC2NuclearControl.instance.screenManager.getWorldKey(advancedExtender.getWorldObj())) == null ) {
+					wasRendered = true;
+				} else {
 					for (Screen screen : IC2NuclearControl.instance.screenManager.getScreens().get(
 						IC2NuclearControl.instance.screenManager.getWorldKey(advancedExtender.getWorldObj()))) {
 						if (screen != null && screen.isBlockPartOf(advancedExtender)) {


### PR DESCRIPTION
Related to https://github.com/GTNewHorizons/Nuclear-Control/pull/11
```
java.lang.NullPointerException: Unexpected error
	at shedar.mods.ic2.nuclearcontrol.renderers.MainBlockRenderer.renderWorldBlock(MainBlockRenderer.java:125)
	at cpw.mods.fml.client.registry.RenderingRegistry.renderWorldBlock(RenderingRegistry.java:118)
	at FMLRenderAccessLibrary.renderWorldBlock(FMLRenderAccessLibrary.java:53)
	at net.minecraft.client.renderer.RenderBlocks.func_147805_b(RenderBlocks.java:296)
```