### PR TITLE
Do not require "enter" press to save info panel text

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/GuiInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/GuiInfoPanel.java
@@ -362,13 +362,14 @@ public class GuiInfoPanel extends GuiContainer {
 
     @Override
     protected void keyTyped(char par1, int par2) {
-        if (textboxTitle != null && textboxTitle.isFocused()) if (par2 == 1) mc.thePlayer.closeScreen();
-        else if (par1 == 13) updateTitle();
-        else {
-            modified = true;
-            textboxTitle.textboxKeyTyped(par1, par2);
-            updateTitle();
-        }
-        else super.keyTyped(par1, par2);
+        if (textboxTitle != null && textboxTitle.isFocused()) {
+            if (par2 == 1) mc.thePlayer.closeScreen();
+            else if (par1 == 13) updateTitle();
+            else {
+                modified = true;
+                textboxTitle.textboxKeyTyped(par1, par2);
+                updateTitle();
+            }
+        } else super.keyTyped(par1, par2);
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/GuiInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/GuiInfoPanel.java
@@ -367,6 +367,7 @@ public class GuiInfoPanel extends GuiContainer {
         else {
             modified = true;
             textboxTitle.textboxKeyTyped(par1, par2);
+            updateTitle();
         }
         else super.keyTyped(par1, par2);
     }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13260

Updates title on all keypresses instead of only when "Enter" is pressed. Requiring user to press enter is unintuitive and gives no feedback when done, and as 13260 shows does not even work for some users.