### PR TITLE
Fix crash when right clicking howler with any gtmetaitem

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,19 +3,19 @@
 dependencies {
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
-    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-310-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-348-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:waila:1.6.5:dev") {
+    compileOnly("com.github.GTNewHorizons:waila:1.7.3:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.4-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.5.25-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.6-GTNH:dev") {
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.10-GTNH:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.25:dev") {
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.153:dev") {
         transitive = false
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -41,7 +41,7 @@ developmentEnvironmentUserName = "Developer"
 
 # Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
-enableModernJavaSyntax = false
+enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
@@ -50,10 +50,10 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = shedar.mods.ic2.nuclearcontrol.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -61,13 +61,16 @@ gradleTokenModId =
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
 
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
+
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = IC2NuclearControl.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -114,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
 }
 
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/IC2NuclearControl.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/IC2NuclearControl.java
@@ -57,7 +57,7 @@ import shedar.mods.ic2.nuclearcontrol.recipes.RecipesOld;
 @Mod(
         modid = "IC2NuclearControl",
         name = "Nuclear Control 2",
-        version = "GRADLETOKEN_VERSION",
+        version = Tags.VERSION,
         dependencies = "required-after:IC2; after:gregtech;",
         guiFactory = "shedar.mods.ic2.nuclearcontrol.gui.GuiFactory")
 public class IC2NuclearControl {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/BlockNuclearControlMain.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/BlockNuclearControlMain.java
@@ -403,23 +403,24 @@ public class BlockNuclearControlMain extends BlockContainer {
             float f3) {
         int blockType = world.getBlockMetadata(x, y, z);
         TileEntity tileEntity = world.getTileEntity(x, y, z);
-        if (tileEntity instanceof TileEntityHowlerAlarm) {
+        if (tileEntity instanceof TileEntityHowlerAlarm tileHowler) {
             if (player.getCurrentEquippedItem() != null && DyeUtil.isADye(player.getCurrentEquippedItem())) {
-                ((TileEntityHowlerAlarm) tileEntity)
-                        .setColor(ItemDye.field_150922_c[DyeUtil.getDyeId(player.getCurrentEquippedItem())]);
-                world.markBlockForUpdate(x, y, z);
-                if (!player.capabilities.isCreativeMode) {
-                    if (player.inventory.getCurrentItem().stackSize == 1) {
-                        player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
-                    } else {
-                        player.inventory.getCurrentItem().stackSize--;
+                int dyeId = DyeUtil.getDyeId(player.getCurrentEquippedItem());
+                if(dyeId >= 0){
+                    tileHowler.setColor(ItemDye.field_150922_c[dyeId]);
+                    world.markBlockForUpdate(x, y, z);
+                    if (!player.capabilities.isCreativeMode) {
+                        if (player.inventory.getCurrentItem().stackSize == 1) {
+                            player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
+                        } else {
+                            player.inventory.getCurrentItem().stackSize--;
+                        }
                     }
+                    return true;
                 }
-                return true;
             } else if (player.getCurrentEquippedItem() != null) {
-                if (player.getCurrentEquippedItem().getItem() instanceof ItemToolPainter) {
-                    ItemToolPainter p = (ItemToolPainter) player.getCurrentEquippedItem().getItem();
-                    ((TileEntityHowlerAlarm) tileEntity).setColor(ItemDye.field_150922_c[p.color]);
+                if (player.getCurrentEquippedItem().getItem() instanceof ItemToolPainter toolPainter) {
+                    tileHowler.setColor(ItemDye.field_150922_c[toolPainter.color]);
                     world.markBlockForUpdate(x, y, z);
                     player.getCurrentEquippedItem().damageItem(1, player);
                     return true;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/BlockNuclearControlMain.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/BlockNuclearControlMain.java
@@ -406,7 +406,7 @@ public class BlockNuclearControlMain extends BlockContainer {
         if (tileEntity instanceof TileEntityHowlerAlarm tileHowler) {
             if (player.getCurrentEquippedItem() != null && DyeUtil.isADye(player.getCurrentEquippedItem())) {
                 int dyeId = DyeUtil.getDyeId(player.getCurrentEquippedItem());
-                if(dyeId >= 0){
+                if (dyeId >= 0) {
                     tileHowler.setColor(ItemDye.field_150922_c[dyeId]);
                     world.markBlockForUpdate(x, y, z);
                     if (!player.capabilities.isCreativeMode) {


### PR DESCRIPTION
The crash happens because some gtmetaitems are oredicted as dyes which apparently causes oredict to think all of them are. 
The problem arises when NC tries to verify that its the correct item since someone decided to return -1 as the dye id if the item damage doesn't match which in turn causes the AIOOBE. [(They even left a nice comment recognizing that it would cause issues) ](https://github.com/GTNewHorizons/Nuclear-Control/blob/457baaa25c2f2214159d77b10edbc3aeeacf76c4/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DyeUtil.java#L56)

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15986