### PR TITLE
nuke ic2 recipe registration

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/appeng/AppengRecipes.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/appeng/AppengRecipes.java
@@ -5,12 +5,17 @@ import net.minecraft.item.ItemStack;
 
 import appeng.api.AEApi;
 import appeng.api.util.AEColor;
+import cpw.mods.fml.common.Loader;
 import ic2.api.item.IC2Items;
 import ic2.api.recipe.Recipes;
 
 public class AppengRecipes {
 
     public static void addRecipesToRegistry() {
+
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
 
         // AE Kit
         Recipes.advRecipes.addRecipe(
@@ -28,6 +33,10 @@ public class AppengRecipes {
     }
 
     public static void addGregtechRecipes() {
+
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
 
         // AE Kit
         Recipes.advRecipes.addRecipe(

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/gregtech/GregtechRecipes.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/gregtech/GregtechRecipes.java
@@ -6,6 +6,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import ic2.api.item.IC2Items;
 import ic2.api.recipe.Recipes;
@@ -19,25 +20,19 @@ import shedar.mods.ic2.nuclearcontrol.utils.LightDamages;
 
 public class GregtechRecipes {
 
-    private static Item gtmeta1;
-    private static ItemStack gtComputerMonitor;
-    private static ItemStack gtSensor;
-    private static ItemStack gtEmitter;
-
-    /**
-     * Grabs all the nessary items/itemstacks from GT indirectly.
-     * 
-     * @author xbony2
-     */
-    public static void grabItems() {
-        gtmeta1 = GameRegistry.findItem("gregtech", "gt.metaitem.01");
-        gtComputerMonitor = new ItemStack(gtmeta1, 1, 32740);
-        gtSensor = new ItemStack(gtmeta1, 1, 32690);
-        gtEmitter = new ItemStack(gtmeta1, 1, 32680);
-    }
-
     public static void addRecipes() {
-        GregtechRecipes.grabItems();
+
+        CraftingManager.getInstance().getRecipeList().add(new StorageArrayRecipe());
+
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
+
+        final Item gtmeta1 = GameRegistry.findItem("gregtech", "gt.metaitem.01");
+        final ItemStack gtComputerMonitor = new ItemStack(gtmeta1, 1, 32740);
+        final ItemStack gtSensor = new ItemStack(gtmeta1, 1, 32690);
+        final ItemStack gtEmitter = new ItemStack(gtmeta1, 1, 32680);
+
         Recipes.advRecipes.addRecipe(
                 new ItemStack(IC2NuclearControl.itemToolThermometer),
                 new Object[] { "BG ", "GMG", " GI", 'B', "boltIron", 'G', "plateGlass", 'M', "cellMercury", 'I',
@@ -245,6 +240,5 @@ public class GregtechRecipes {
                                 BlockDamages.DAMAGE_INFO_PANEL_EXTENDER),
                         'R', IC2NuclearControl.itemUpgrade, 'P', "plateStainlessSteel" });
 
-        CraftingManager.getInstance().getRecipeList().add(new StorageArrayRecipe());
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/vanilla/Vanilla.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/vanilla/Vanilla.java
@@ -5,6 +5,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import ic2.api.item.IC2Items;
 import ic2.api.recipe.Recipes;
@@ -24,6 +25,10 @@ public class Vanilla {
         GameRegistry.registerItem(inventoryCard, "ItemInventoryScannerCard");
         GameRegistry.registerItem(vanillaKit, "ItemVanilliaKit");
         GameRegistry.registerItem(machineCard, "ItemVanillaMachineCard");
+
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
 
         Recipes.advRecipes.addRecipe(
                 new ItemStack(vanillaKit),

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/recipes/RecipesNew.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/recipes/RecipesNew.java
@@ -5,6 +5,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 
+import cpw.mods.fml.common.Loader;
 import ic2.api.item.IC2Items;
 import ic2.api.recipe.Recipes;
 import ic2.core.util.StackUtil;
@@ -18,6 +19,13 @@ import shedar.mods.ic2.nuclearcontrol.utils.LightDamages;
 public class RecipesNew {
 
     public static void addRecipes() {
+
+        CraftingManager.getInstance().getRecipeList().add(new StorageArrayRecipe());
+
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
+
         ItemStack thermalMonitor = new ItemStack(
                 IC2NuclearControl.blockNuclearControlMain,
                 1,
@@ -220,6 +228,5 @@ public class RecipesNew {
                 IC2Items.getItem("electronicCircuit"),
                 IC2NuclearControl.itemMultipleSensorLocationCard);
 
-        CraftingManager.getInstance().getRecipeList().add(new StorageArrayRecipe());
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/recipes/RecipesOld.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/recipes/RecipesOld.java
@@ -5,6 +5,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 
+import cpw.mods.fml.common.Loader;
 import ic2.api.item.IC2Items;
 import ic2.api.recipe.Recipes;
 import ic2.core.util.StackUtil;
@@ -19,6 +20,13 @@ public class RecipesOld {
 
     @Deprecated // It's not :P ~Chocohead
     public static void addOldRecipes() {
+
+        CraftingManager.getInstance().getRecipeList().add(new StorageArrayRecipe());
+
+        if (Loader.isModLoaded("dreamcraft")) {
+            return;
+        }
+
         ItemStack thermalMonitor = new ItemStack(
                 IC2NuclearControl.blockNuclearControlMain,
                 1,
@@ -220,6 +228,5 @@ public class RecipesOld {
                 new ItemStack(IC2Items.getItem("electronicCircuit").getItem(), 1),
                 new ItemStack(IC2NuclearControl.itemTimeCard, 1));
 
-        CraftingManager.getInstance().getRecipeList().add(new StorageArrayRecipe());
     }
 }


### PR DESCRIPTION
Prevents adding recipes into the IC2 recipes maps when we have dreamcraft loaded