### PR TITLE
Fix facing bug

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAverageCounter.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAverageCounter.java
@@ -81,6 +81,9 @@ public class TileEntityAverageCounter extends TileEntity
     }
 
     protected void initData() {
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
+        }
         init = true;
     }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityEnergyCounter.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityEnergyCounter.java
@@ -68,6 +68,9 @@ public class TileEntityEnergyCounter extends TileEntity
     }
 
     protected void initData() {
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
+        }
         init = true;
     }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityHowlerAlarm.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityHowlerAlarm.java
@@ -74,6 +74,9 @@ public class TileEntityHowlerAlarm extends TileEntity implements INetworkDataPro
         if (!worldObj.isRemote) {
             RedstoneHelper.checkPowered(worldObj, this);
         }
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
+        }
         if (FMLCommonHandler.instance().getEffectiveSide().isServer() && "".equals(soundName)) {
             setSoundName(DEFAULT_SOUND_NAME);
         }
@@ -248,6 +251,7 @@ public class TileEntityHowlerAlarm extends TileEntity implements INetworkDataPro
         if (!init) {
             initData();
         }
+
         super.updateEntity();
         if (FMLCommonHandler.instance().getEffectiveSide().isClient()) {
             if (tickRate != -1 && updateTicker-- > 0) return;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -350,6 +350,7 @@ public class TileEntityInfoPanel extends TileEntity
             RedstoneHelper.checkPowered(worldObj, this);
         }
         if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
             if (screenData == null) {
                 IC2NuclearControl.instance.screenManager.registerInfoPanel(this);
             } else {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanelExtender.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanelExtender.java
@@ -99,6 +99,9 @@ public class TileEntityInfoPanelExtender extends TileEntity
         if (FMLCommonHandler.instance().getEffectiveSide().isServer() && !partOfScreen) {
             IC2NuclearControl.instance.screenManager.registerInfoPanelExtender(this);
         }
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
+        }
         if (partOfScreen && screen == null) {
             TileEntity core = worldObj.getTileEntity(coreX, coreY, coreZ);
             if (core != null && core instanceof TileEntityInfoPanel) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityRangeTrigger.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityRangeTrigger.java
@@ -217,6 +217,9 @@ public class TileEntityRangeTrigger extends TileEntity
         if (!worldObj.isRemote) {
             worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
         }
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
+        }
         init = true;
     }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityThermo.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityThermo.java
@@ -10,6 +10,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Facing;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import ic2.api.network.INetworkClientTileEntityEventListener;
 import ic2.api.network.INetworkDataProvider;
 import ic2.api.network.INetworkUpdateListener;
@@ -61,7 +62,9 @@ public class TileEntityThermo extends TileEntity implements INetworkDataProvider
     protected void initData() {
         if (!worldObj.isRemote)
             worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, worldObj.getBlock(xCoord, yCoord, zCoord));
-
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "facing");
+        }
         init = true;
     }
 


### PR DESCRIPTION
Fix for [this issue](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20757).

All TileEntities now send their facing data when initialising.