### PR TITLE
Improve panel rendering with extenders, reduce unnecessary allocations

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
@@ -10,6 +10,7 @@ import shedar.mods.ic2.nuclearcontrol.IScreenPart;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityInfoPanel;
 
 public class Screen {
+
     public int minX;
     public int minY;
     public int minZ;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
@@ -2,6 +2,7 @@ package shedar.mods.ic2.nuclearcontrol.panel;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
@@ -9,7 +10,6 @@ import shedar.mods.ic2.nuclearcontrol.IScreenPart;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityInfoPanel;
 
 public class Screen {
-
     public int minX;
     public int minY;
     public int minZ;
@@ -20,11 +20,16 @@ public class Screen {
     private int coreY;
     private int coreZ;
     private boolean powered = false;
+    private AxisAlignedBB boundingBox;
 
     public TileEntityInfoPanel getCore(IBlockAccess world) {
         TileEntity tileEntity = world.getTileEntity(coreX, coreY, coreZ);
         if (tileEntity == null || !(tileEntity instanceof TileEntityInfoPanel)) return null;
         return (TileEntityInfoPanel) tileEntity;
+    }
+
+    public AxisAlignedBB getBoundingBox() {
+        return boundingBox;
     }
 
     public void setCore(TileEntityInfoPanel core) {
@@ -54,6 +59,7 @@ public class Screen {
     }
 
     public void init(boolean force, World world) {
+        boundingBox = AxisAlignedBB.getBoundingBox(minX, minY, minZ, maxX + 1, maxY + 1, maxZ + 1);
         for (int x = minX; x <= maxX; x++) {
             for (int y = minY; y <= maxY; y++) {
                 for (int z = minZ; z <= maxZ; z++) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/ScreenManager.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/ScreenManager.java
@@ -137,7 +137,7 @@ public class ScreenManager {
     }
 
     private Screen tryBuildFromPanel(TileEntityInfoPanel panel) {
-        boolean advanced = panel instanceof TileEntityAdvancedInfoPanel;
+        boolean isAdvanced = panel instanceof TileEntityAdvancedInfoPanel;
         Screen screen = new Screen();
         screen.maxX = screen.minX = panel.xCoord;
         screen.maxY = screen.minY = panel.yCoord;
@@ -146,12 +146,13 @@ public class ScreenManager {
         int dx = Facing.offsetsXForSide[panel.facing] != 0 ? 0 : -1;
         int dy = Facing.offsetsYForSide[panel.facing] != 0 ? 0 : -1;
         int dz = Facing.offsetsZForSide[panel.facing] != 0 ? 0 : -1;
-        updateScreenBound(screen, dx, 0, 0, panel.getWorldObj(), advanced);
-        updateScreenBound(screen, -dx, 0, 0, panel.getWorldObj(), advanced);
-        updateScreenBound(screen, 0, dy, 0, panel.getWorldObj(), advanced);
-        updateScreenBound(screen, 0, -dy, 0, panel.getWorldObj(), advanced);
-        updateScreenBound(screen, 0, 0, dz, panel.getWorldObj(), advanced);
-        updateScreenBound(screen, 0, 0, -dz, panel.getWorldObj(), advanced);
+        updateScreenBound(screen, dx, 0, 0, panel.getWorldObj(), isAdvanced);
+        updateScreenBound(screen, -dx, 0, 0, panel.getWorldObj(), isAdvanced);
+        updateScreenBound(screen, 0, dy, 0, panel.getWorldObj(), isAdvanced);
+        updateScreenBound(screen, 0, -dy, 0, panel.getWorldObj(), isAdvanced);
+        updateScreenBound(screen, 0, 0, dz, panel.getWorldObj(), isAdvanced);
+        updateScreenBound(screen, 0, 0, -dz, panel.getWorldObj(), isAdvanced);
+        if (isAdvanced) ((TileEntityAdvancedInfoPanel) panel).screenModelInfo.update(screen);
         screen.init(false, panel.getWorldObj());
         panel.updateData();
         return screen;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
@@ -95,8 +95,7 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
             }
             if (tileEntity instanceof TileEntityAdvancedInfoPanel) {
                 TileEntityAdvancedInfoPanel advancedCore = (TileEntityAdvancedInfoPanel) tileEntity;
-                if (advancedCore.getScreen() != null)
-                    advancedCore.screenModelInfo.renderScreen(block);
+                if (advancedCore.getScreen() != null) advancedCore.screenModelInfo.renderScreen(block);
                 else renderer.renderStandardBlock(block, x, y, z);
 
             } else if (tileEntity instanceof TileEntityAdvancedInfoPanelExtender) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
@@ -15,7 +15,6 @@ import shedar.mods.ic2.nuclearcontrol.IC2NuclearControl;
 import shedar.mods.ic2.nuclearcontrol.IRotation;
 import shedar.mods.ic2.nuclearcontrol.blocks.BlockNuclearControlMain;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
-import shedar.mods.ic2.nuclearcontrol.renderers.model.ModelInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanelExtender;
 
@@ -97,7 +96,7 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
             if (tileEntity instanceof TileEntityAdvancedInfoPanel) {
                 TileEntityAdvancedInfoPanel advancedCore = (TileEntityAdvancedInfoPanel) tileEntity;
                 if (advancedCore.getScreen() != null)
-                    new ModelInfoPanel().renderScreen(block, advancedCore, x, y, z, renderer);
+                    advancedCore.screenModelInfo.renderScreen(block);
                 else renderer.renderStandardBlock(block, x, y, z);
 
             } else if (tileEntity instanceof TileEntityAdvancedInfoPanelExtender) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -34,7 +34,8 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
         renderPanelTileEntity(panel, joinedPanelStrings, x, y, z);
     }
 
-    private void renderPanelTileEntity(TileEntityInfoPanel panel, List<PanelString> panelStrings, double x, double y, double z) {
+    private void renderPanelTileEntity(TileEntityInfoPanel panel, List<PanelString> panelStrings, double x, double y,
+            double z) {
         GL11.glPushMatrix();
         GL11.glPolygonOffset(-10, -10);
         GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -13,297 +13,271 @@ import net.minecraft.util.Facing;
 
 import org.lwjgl.opengl.GL11;
 
-import shedar.mods.ic2.nuclearcontrol.IScreenPart;
 import shedar.mods.ic2.nuclearcontrol.api.CardState;
 import shedar.mods.ic2.nuclearcontrol.api.DisplaySettingHelper;
 import shedar.mods.ic2.nuclearcontrol.api.IPanelDataSource;
 import shedar.mods.ic2.nuclearcontrol.api.PanelString;
 import shedar.mods.ic2.nuclearcontrol.panel.CardWrapperImpl;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
-import shedar.mods.ic2.nuclearcontrol.renderers.model.ModelInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.utils.StringUtils;
 
 public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
-    private static String implodeArray(String[] inputArray, String glueString) {
-        String output = "";
-        if (inputArray.length > 0) {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < inputArray.length; i++) {
-                if (inputArray[i] == null || inputArray[i].isEmpty()) continue;
-                sb.append(glueString);
-                sb.append(inputArray[i]);
-            }
-            output = sb.toString();
-            if (output.length() > 1) output = output.substring(1);
-        }
-        return output;
-    }
-
     @Override
     public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float f) {
-        boolean isPanel = tileEntity instanceof TileEntityInfoPanel;
-        if (!isPanel && tileEntity instanceof IScreenPart) {
-            Screen scr = ((IScreenPart) tileEntity).getScreen();
-            if (scr != null) {
-                TileEntity core = scr.getCore(tileEntity.getWorldObj());
-                if (core != null) {
-                    x += core.xCoord - tileEntity.xCoord;
-                    y += core.yCoord - tileEntity.yCoord;
-                    z += core.zCoord - tileEntity.zCoord;
-                    tileEntity = core;
-                    isPanel = tileEntity instanceof TileEntityInfoPanel;
-                }
-            }
-        }
+        if (!(tileEntity instanceof TileEntityInfoPanel panel)) return;
+        if (!panel.getPowered()) return;
 
-        if (isPanel) {
-            TileEntityInfoPanel panel = (TileEntityInfoPanel) tileEntity;
-            if (!panel.getPowered()) {
-                return;
-            }
-            List<ItemStack> cards = panel.getCards();
-            boolean anyCardFound = false;
-            List<PanelString> joinedData = new LinkedList<PanelString>();
-            for (ItemStack card : cards) {
-                if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
-                    continue;
-                }
-                DisplaySettingHelper displaySettings = panel.getNewDisplaySettingsByCard(card);
+        List<PanelString> joinedPanelStrings = getPanelStrings(panel);
+        renderPanelTileEntity(panel, joinedPanelStrings, x, y, z);
+    }
 
-                CardWrapperImpl helper = new CardWrapperImpl(card, -1);
-                CardState state = helper.getState();
-                List<PanelString> data;
-                if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {
-                    data = StringUtils.getStateMessage(state);
-                } else {
-                    if (panel instanceof TileEntityAdvancedInfoPanel) {
-                        data = ((TileEntityAdvancedInfoPanel) panel).getSortedCardData(displaySettings, card, helper);
-                    } else {
-                        data = panel.getCardData(displaySettings, card, helper);
-                    }
-                }
-                if (data == null) {
-                    continue;
-                }
-                joinedData.addAll(data);
-                anyCardFound = true;
-            }
-            if (!anyCardFound) {
-                return;
-            }
-
-            GL11.glPushMatrix();
-            GL11.glPolygonOffset(-10, -10);
-            GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);
-            short side = (short) Facing.oppositeSide[panel.getFacing()];
-            Screen screen = panel.getScreen();
-            float dx = 1F / 16;
-            float dz = 1F / 16;
-            float displayWidth = 1 - 2F / 16;
-            float displayHeight = 1 - 2F / 16;
-            if (screen != null) {
-                y -= panel.yCoord - screen.maxY;
-                if (side == 0 || side == 1 || side == 2 || side == 3 || side == 5) {
-                    z -= panel.zCoord - screen.minZ;
-                } else {
-                    z -= panel.zCoord - screen.maxZ;
-                }
-
-                if (side == 0 || side == 2 || side == 4) {
-                    x -= panel.xCoord - screen.minX;
-                } else {
-                    x -= panel.xCoord - screen.maxX;
-                }
-            }
-            GL11.glTranslatef((float) x, (float) y, (float) z);
-            switch (side) {
-                case 0:
-                    if (screen != null) {
-                        displayWidth += screen.maxX - screen.minX;
-                        displayHeight += screen.maxZ - screen.minZ;
-                    }
-                    break;
-                case 1:
-                    GL11.glTranslatef(1, 1, 0);
-                    GL11.glRotatef(180, 1, 0, 0);
-                    GL11.glRotatef(180, 0, 1, 0);
-                    if (screen != null) {
-                        displayWidth += screen.maxX - screen.minX;
-                        displayHeight += screen.maxZ - screen.minZ;
-                    }
-                    break;
-                case 2:
-                    GL11.glTranslatef(0, 1, 0);
-                    GL11.glRotatef(0, 0, 1, 0);
-                    GL11.glRotatef(90, 1, 0, 0);
-                    if (screen != null) {
-                        displayWidth += screen.maxX - screen.minX;
-                        displayHeight += screen.maxY - screen.minY;
-                    }
-                    break;
-                case 3:
-                    GL11.glTranslatef(1, 1, 1);
-                    GL11.glRotatef(180, 0, 1, 0);
-                    GL11.glRotatef(90, 1, 0, 0);
-                    if (screen != null) {
-                        displayWidth += screen.maxX - screen.minX;
-                        displayHeight += screen.maxY - screen.minY;
-                    }
-                    break;
-                case 4:
-                    GL11.glTranslatef(0, 1, 1);
-                    GL11.glRotatef(90, 0, 1, 0);
-                    GL11.glRotatef(90, 1, 0, 0);
-                    if (screen != null) {
-                        displayWidth += screen.maxZ - screen.minZ;
-                        displayHeight += screen.maxY - screen.minY;
-                    }
-                    break;
-                case 5:
-                    GL11.glTranslatef(1, 1, 0);
-                    GL11.glRotatef(-90, 0, 1, 0);
-                    GL11.glRotatef(90, 1, 0, 0);
-                    if (screen != null) {
-                        displayWidth += screen.maxZ - screen.minZ;
-                        displayHeight += screen.maxY - screen.minY;
-                    }
-                    break;
-            }
-            float thickness = 1;
-            double angleHor = 0;
-            double angleVert = 0;
-            double[] deltas = null;
-            if (panel instanceof TileEntityAdvancedInfoPanel && screen != null) {
-                TileEntityAdvancedInfoPanel advPanel = (TileEntityAdvancedInfoPanel) panel;
-                ModelInfoPanel model = new ModelInfoPanel();
-                deltas = model.getDeltas(advPanel, screen);
-                thickness = (float) (advPanel.thickness / 16F - (deltas[0] + deltas[1] + deltas[2] + deltas[3]) / 4);
-            }
-
-            GL11.glTranslatef(dx + displayWidth / 2, thickness, dz + displayHeight / 2);
-            GL11.glRotatef(-90, 1, 0, 0);
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-
-            switch (panel.rotation) {
-                case 0:
-                    break;
-                case 1:
-                    GL11.glRotatef(-90, 0, 0, 1);
-                    float t = displayHeight;
-                    displayHeight = displayWidth;
-                    displayWidth = t;
-                    break;
-                case 2:
-                    GL11.glRotatef(90, 0, 0, 1);
-                    float tm = displayHeight;
-                    displayHeight = displayWidth;
-                    displayWidth = tm;
-                    break;
-                case 3:
-                    GL11.glRotatef(180, 0, 0, 1);
-                    break;
-            }
-            if (deltas != null) {
-                if (deltas[0] == 0) {
-                    // +1,-2
-                    angleHor = 180 / Math.PI * Math.atan(deltas[1] / (displayWidth + 2F / 16));
-                    angleVert = -180 / Math.PI * Math.atan(deltas[2] / (displayHeight + 2F / 16));
-                } else if (deltas[1] == 0) {
-                    // -0,-3
-                    angleHor = -180 / Math.PI * Math.atan(deltas[0] / (displayWidth + 2F / 16));
-                    angleVert = -180 / Math.PI * Math.atan(deltas[3] / (displayHeight + 2F / 16));
-                } else if (deltas[2] == 0) {
-                    // +3,+0
-                    angleHor = 180 / Math.PI * Math.atan(deltas[3] / (displayWidth + 2F / 16));
-                    angleVert = 180 / Math.PI * Math.atan(deltas[0] / (displayHeight + 2F / 16));
-                } else {
-                    // -2,+1
-                    angleHor = -180 / Math.PI * Math.atan(deltas[2] / (displayWidth + 2F / 16));
-                    angleVert = 180 / Math.PI * Math.atan(deltas[1] / (displayHeight + 2F / 16));
-                }
-            }
-            GL11.glRotatef((float) -angleVert, 1, 0, 0);
-            GL11.glRotatef((float) angleHor, 0, 1, 0);
-            // Do text rotation here
-            GL11.glRotatef((float) panel.getTextRotation() * 90.0f, 0, 0, 1);
-            FontRenderer fontRenderer = this.func_147498_b();
-
-            int maxWidth = 1;
-            for (PanelString panelString : joinedData) {
-                String currentString = implodeArray(
-                        new String[] { panelString.textLeft, panelString.textCenter, panelString.textRight },
-                        " ");
-                maxWidth = Math.max(fontRenderer.getStringWidth(currentString), maxWidth);
-            }
-            maxWidth += 4;
-
-            int lineHeight = fontRenderer.FONT_HEIGHT + 2;
-            int requiredHeight = lineHeight * joinedData.size();
-            if (panel.getTextRotation() == 1 || panel.getTextRotation() == 3) {
-                float tm = displayWidth;
-                displayWidth = displayHeight;
-                displayHeight = tm;
-            }
-            float scaleX = displayWidth / maxWidth;
-            float scaleY = displayHeight / requiredHeight;
-            float scale = Math.min(scaleX, scaleY);
-            GL11.glScalef(scale, -scale, scale);
-
-            int offsetX;
-            int offsetY;
-
-            int realHeight = (int) Math.floor(displayHeight / scale);
-            int realWidth = (int) Math.floor(displayWidth / scale);
-
-            if (scaleX < scaleY) {
-                offsetX = 2;
-                offsetY = (realHeight - requiredHeight) / 2;
+    private void renderPanelTileEntity(TileEntityInfoPanel panel, List<PanelString> panelStrings, double x, double y, double z) {
+        GL11.glPushMatrix();
+        GL11.glPolygonOffset(-10, -10);
+        GL11.glEnable(GL11.GL_POLYGON_OFFSET_FILL);
+        short side = (short) Facing.oppositeSide[panel.getFacing()];
+        Screen screen = panel.getScreen();
+        float dx = 1F / 16;
+        float dz = 1F / 16;
+        float displayWidth = 1 - 2F / 16;
+        float displayHeight = 1 - 2F / 16;
+        if (screen != null) {
+            y -= panel.yCoord - screen.maxY;
+            if (side == 0 || side == 1 || side == 2 || side == 3 || side == 5) {
+                z -= panel.zCoord - screen.minZ;
             } else {
-                offsetX = (realWidth - maxWidth) / 2 + 2;
-                offsetY = 0;
-            }
-            Block block = panel.getWorldObj().getBlock(panel.xCoord, panel.yCoord, panel.zCoord);
-            if (block == null) {
-                block = Blocks.stone;
+                z -= panel.zCoord - screen.maxZ;
             }
 
-            GL11.glDisable(GL11.GL_LIGHTING);
-
-            int row = 0;
-            for (PanelString panelString : joinedData) {
-                if (panelString.textLeft != null) {
-                    fontRenderer.drawString(
-                            panelString.textLeft,
-                            offsetX - realWidth / 2,
-                            1 + offsetY - realHeight / 2 + row * lineHeight,
-                            panelString.colorLeft != 0 ? panelString.colorLeft : panel.getColorTextHex());
-                }
-                if (panelString.textCenter != null) {
-                    fontRenderer.drawString(
-                            panelString.textCenter,
-                            -fontRenderer.getStringWidth(panelString.textCenter) / 2,
-                            offsetY - realHeight / 2 + row * lineHeight,
-                            panelString.colorCenter != 0 ? panelString.colorCenter : panel.getColorTextHex());
-                }
-                if (panelString.textRight != null) {
-                    fontRenderer.drawString(
-                            panelString.textRight,
-                            realWidth / 2 - fontRenderer.getStringWidth(panelString.textRight),
-                            offsetY - realHeight / 2 + row * lineHeight,
-                            panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
-                }
-                row++;
+            if (side == 0 || side == 2 || side == 4) {
+                x -= panel.xCoord - screen.minX;
+            } else {
+                x -= panel.xCoord - screen.maxX;
             }
-
-            GL11.glEnable(GL11.GL_LIGHTING);
-
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-
-            GL11.glDisable(GL11.GL_POLYGON_OFFSET_FILL);
-            GL11.glPopMatrix();
         }
+        GL11.glTranslatef((float) x, (float) y, (float) z);
+        switch (side) {
+            case 0:
+                if (screen != null) {
+                    displayWidth += screen.maxX - screen.minX;
+                    displayHeight += screen.maxZ - screen.minZ;
+                }
+                break;
+            case 1:
+                GL11.glTranslatef(1, 1, 0);
+                GL11.glRotatef(180, 1, 0, 0);
+                GL11.glRotatef(180, 0, 1, 0);
+                if (screen != null) {
+                    displayWidth += screen.maxX - screen.minX;
+                    displayHeight += screen.maxZ - screen.minZ;
+                }
+                break;
+            case 2:
+                GL11.glTranslatef(0, 1, 0);
+                GL11.glRotatef(0, 0, 1, 0);
+                GL11.glRotatef(90, 1, 0, 0);
+                if (screen != null) {
+                    displayWidth += screen.maxX - screen.minX;
+                    displayHeight += screen.maxY - screen.minY;
+                }
+                break;
+            case 3:
+                GL11.glTranslatef(1, 1, 1);
+                GL11.glRotatef(180, 0, 1, 0);
+                GL11.glRotatef(90, 1, 0, 0);
+                if (screen != null) {
+                    displayWidth += screen.maxX - screen.minX;
+                    displayHeight += screen.maxY - screen.minY;
+                }
+                break;
+            case 4:
+                GL11.glTranslatef(0, 1, 1);
+                GL11.glRotatef(90, 0, 1, 0);
+                GL11.glRotatef(90, 1, 0, 0);
+                if (screen != null) {
+                    displayWidth += screen.maxZ - screen.minZ;
+                    displayHeight += screen.maxY - screen.minY;
+                }
+                break;
+            case 5:
+                GL11.glTranslatef(1, 1, 0);
+                GL11.glRotatef(-90, 0, 1, 0);
+                GL11.glRotatef(90, 1, 0, 0);
+                if (screen != null) {
+                    displayWidth += screen.maxZ - screen.minZ;
+                    displayHeight += screen.maxY - screen.minY;
+                }
+                break;
+        }
+        float thickness = 1;
+        double angleHor = 0;
+        double angleVert = 0;
+        double[] deltas = null;
+        if (panel instanceof TileEntityAdvancedInfoPanel && screen != null) {
+            TileEntityAdvancedInfoPanel advPanel = (TileEntityAdvancedInfoPanel) panel;
+            deltas = advPanel.screenModelInfo.getDeltas();
+            thickness = (float) (advPanel.thickness / 16F - (deltas[0] + deltas[1] + deltas[2] + deltas[3]) / 4);
+        }
+
+        GL11.glTranslatef(dx + displayWidth / 2, thickness, dz + displayHeight / 2);
+        GL11.glRotatef(-90, 1, 0, 0);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+
+        switch (panel.rotation) {
+            case 0:
+                break;
+            case 1:
+                GL11.glRotatef(-90, 0, 0, 1);
+                float t = displayHeight;
+                displayHeight = displayWidth;
+                displayWidth = t;
+                break;
+            case 2:
+                GL11.glRotatef(90, 0, 0, 1);
+                float tm = displayHeight;
+                displayHeight = displayWidth;
+                displayWidth = tm;
+                break;
+            case 3:
+                GL11.glRotatef(180, 0, 0, 1);
+                break;
+        }
+        if (deltas != null) {
+            if (deltas[0] == 0) {
+                // +1,-2
+                angleHor = 180 / Math.PI * Math.atan(deltas[1] / (displayWidth + 2F / 16));
+                angleVert = -180 / Math.PI * Math.atan(deltas[2] / (displayHeight + 2F / 16));
+            } else if (deltas[1] == 0) {
+                // -0,-3
+                angleHor = -180 / Math.PI * Math.atan(deltas[0] / (displayWidth + 2F / 16));
+                angleVert = -180 / Math.PI * Math.atan(deltas[3] / (displayHeight + 2F / 16));
+            } else if (deltas[2] == 0) {
+                // +3,+0
+                angleHor = 180 / Math.PI * Math.atan(deltas[3] / (displayWidth + 2F / 16));
+                angleVert = 180 / Math.PI * Math.atan(deltas[0] / (displayHeight + 2F / 16));
+            } else {
+                // -2,+1
+                angleHor = -180 / Math.PI * Math.atan(deltas[2] / (displayWidth + 2F / 16));
+                angleVert = 180 / Math.PI * Math.atan(deltas[1] / (displayHeight + 2F / 16));
+            }
+        }
+        GL11.glRotatef((float) -angleVert, 1, 0, 0);
+        GL11.glRotatef((float) angleHor, 0, 1, 0);
+        // Do text rotation here
+        GL11.glRotatef((float) panel.getTextRotation() * 90.0f, 0, 0, 1);
+        FontRenderer fontRenderer = this.func_147498_b();
+
+        int maxWidth = 1;
+        StringBuilder widthSb = new StringBuilder();
+        for (PanelString panelString : panelStrings) {
+            widthSb.setLength(0);
+            if (panelString.textLeft != null && !panelString.textLeft.isEmpty()) widthSb.append(panelString.textLeft);
+            if (panelString.textCenter != null && !panelString.textCenter.isEmpty()) {
+                if (widthSb.length() > 0) widthSb.append(' ');
+                widthSb.append(panelString.textCenter);
+            }
+            if (panelString.textRight != null && !panelString.textRight.isEmpty()) {
+                if (widthSb.length() > 0) widthSb.append(' ');
+                widthSb.append(panelString.textRight);
+            }
+            maxWidth = Math.max(fontRenderer.getStringWidth(widthSb.toString()), maxWidth);
+        }
+        maxWidth += 4;
+
+        int lineHeight = fontRenderer.FONT_HEIGHT + 2;
+        int requiredHeight = lineHeight * panelStrings.size();
+        if (panel.getTextRotation() == 1 || panel.getTextRotation() == 3) {
+            float tm = displayWidth;
+            displayWidth = displayHeight;
+            displayHeight = tm;
+        }
+        float scaleX = displayWidth / maxWidth;
+        float scaleY = displayHeight / requiredHeight;
+        float scale = Math.min(scaleX, scaleY);
+        GL11.glScalef(scale, -scale, scale);
+
+        int offsetX;
+        int offsetY;
+
+        int realHeight = (int) Math.floor(displayHeight / scale);
+        int realWidth = (int) Math.floor(displayWidth / scale);
+
+        if (scaleX < scaleY) {
+            offsetX = 2;
+            offsetY = (realHeight - requiredHeight) / 2;
+        } else {
+            offsetX = (realWidth - maxWidth) / 2 + 2;
+            offsetY = 0;
+        }
+        Block block = panel.getWorldObj().getBlock(panel.xCoord, panel.yCoord, panel.zCoord);
+        if (block == null) {
+            block = Blocks.stone;
+        }
+
+        GL11.glDisable(GL11.GL_LIGHTING);
+
+        int row = 0;
+        for (PanelString panelString : panelStrings) {
+            if (panelString.textLeft != null) {
+                fontRenderer.drawString(
+                        panelString.textLeft,
+                        offsetX - realWidth / 2,
+                        1 + offsetY - realHeight / 2 + row * lineHeight,
+                        panelString.colorLeft != 0 ? panelString.colorLeft : panel.getColorTextHex());
+            }
+            if (panelString.textCenter != null) {
+                fontRenderer.drawString(
+                        panelString.textCenter,
+                        -fontRenderer.getStringWidth(panelString.textCenter) / 2,
+                        offsetY - realHeight / 2 + row * lineHeight,
+                        panelString.colorCenter != 0 ? panelString.colorCenter : panel.getColorTextHex());
+            }
+            if (panelString.textRight != null) {
+                fontRenderer.drawString(
+                        panelString.textRight,
+                        realWidth / 2 - fontRenderer.getStringWidth(panelString.textRight),
+                        offsetY - realHeight / 2 + row * lineHeight,
+                        panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
+            }
+            row++;
+        }
+
+        GL11.glEnable(GL11.GL_LIGHTING);
+
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+
+        GL11.glDisable(GL11.GL_POLYGON_OFFSET_FILL);
+        GL11.glPopMatrix();
+    }
+
+    private List<PanelString> getPanelStrings(TileEntityInfoPanel panel) {
+        List<PanelString> joinedData = new LinkedList<>();
+        for (ItemStack card : panel.getCards()) {
+            if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
+                continue;
+            }
+            DisplaySettingHelper displaySettings = panel.getNewDisplaySettingsByCard(card);
+
+            CardWrapperImpl helper = new CardWrapperImpl(card, -1);
+            CardState state = helper.getState();
+            List<PanelString> data;
+            if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {
+                data = StringUtils.getStateMessage(state);
+            } else {
+                if (panel instanceof TileEntityAdvancedInfoPanel) {
+                    data = ((TileEntityAdvancedInfoPanel) panel).getSortedCardData(displaySettings, card, helper);
+                } else {
+                    data = panel.getCardData(displaySettings, card, helper);
+                }
+            }
+            if (data == null) {
+                continue;
+            }
+            joinedData.addAll(data);
+        }
+        return joinedData;
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ScreenModelInfo.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ScreenModelInfo.java
@@ -1,21 +1,17 @@
 package shedar.mods.ic2.nuclearcontrol.renderers.model;
 
-import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.util.Facing;
-import net.minecraft.util.IIcon;
-
-import org.lwjgl.opengl.GL11;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.IIcon;
+import org.lwjgl.opengl.GL11;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
 
 @SideOnly(Side.CLIENT)
-public class ModelInfoPanel {
+public class ScreenModelInfo {
 
     private static final String TEXTURE_FILE = "nuclearcontrol:infoPanel/panelAdvancedSide";
     private static final IIcon advSideTex = Minecraft.getMinecraft().getTextureMapBlocks().registerIcon(TEXTURE_FILE);
@@ -25,10 +21,17 @@ public class ModelInfoPanel {
     private static final double Vmi = advSideTex.getMinV();
 
     private final double[] coordinates = new double[24];
-    private static final byte[][] pointMap = { { 0, 3, 2, 1 }, { 4, 5, 6, 7 }, { 0, 4, 7, 3 }, { 6, 5, 1, 2 },
+    private static final byte[][] pointMap = { { 0, 3, 2, 1 }, { 4, 5, 6, 7 }, {        0, 4, 7, 3 }, { 6, 5, 1, 2 },
             { 5, 4, 0, 1 }, { 2, 3, 7, 6 } };
     private static final byte[][] normalMap = { { 0, -1, 0 }, { 0, 1, 0 }, { 0, 0, -1 }, { 0, 0, 1 }, { -1, 0, 0 },
             { 1, 0, 0 } };
+
+    private double[] deltas = new double[4];
+    private TileEntityAdvancedInfoPanel panel;
+
+    public ScreenModelInfo(TileEntityAdvancedInfoPanel panel) {
+        this.panel = panel;
+    }
 
     private void assignWithRotation(int rotation, int offset, int sign, int tl, int tr, int br, int bl, double dtl,
             double dtr, double dbr, double dbl) {
@@ -63,15 +66,22 @@ public class ModelInfoPanel {
         }
     }
 
-    public double[] getDeltas(TileEntityAdvancedInfoPanel panel, Screen screen) {
+    public void update(Screen screen) {
+        calculateDeltas(panel);
+        recomputeCoordinates(panel.getBlockType(), screen);
+    }
+
+    public double[] getDeltas() {
+        return deltas;
+    }
+
+    private void calculateDeltas(TileEntityAdvancedInfoPanel panel) {
         boolean isTopBottom = panel.rotateVert != 0;
         boolean isLeftRight = panel.rotateHor != 0;
         double dTopLeft = 0;
         double dTopRight = 0;
         double dBottomLeft = 0;
         double dBottomRight = 0;
-        int height = screen.getHeight(panel);
-        int width = screen.getWidth(panel);
         double maxDelta = 0;
         if (isTopBottom) {
             if (panel.rotateVert > 0) // |\
@@ -112,13 +122,11 @@ public class ModelInfoPanel {
             dBottomLeft = scale * dBottomLeft;
             dBottomRight = scale * dBottomRight;
         }
-        double[] res = { dTopLeft, dTopRight, dBottomLeft, dBottomRight };
-        return res;
+
+        this.deltas = new double[] { dTopLeft, dTopRight, dBottomLeft, dBottomRight };
     }
 
-    private void addSlopes(TileEntityAdvancedInfoPanel panel, Screen screen, double[] deltas) {
-        // if (panel.rotateVert == 0 && panel.rotateHor == 0)
-        // return;
+    private void addSlopes(TileEntityAdvancedInfoPanel panel) {
         double dTopLeft = deltas[0];
         double dTopRight = deltas[1];
         double dBottomLeft = deltas[2];
@@ -147,8 +155,7 @@ public class ModelInfoPanel {
         }
     }
 
-    private void initCoordinates(Block block, Screen screen) {
-
+    private void recomputeCoordinates(Block block, Screen screen) {
         // 5 -------6
         // /| /|
         // 4 -------7 |
@@ -196,6 +203,8 @@ public class ModelInfoPanel {
         coordinates[21] = screen.maxX + blockMaxX;
         coordinates[22] = screen.maxY + blockMaxY;
         coordinates[23] = screen.minZ + blockMinZ;
+
+        addSlopes(panel);
     }
 
     private void addPoint(int point, double u, double v) {
@@ -211,57 +220,67 @@ public class ModelInfoPanel {
         addPoint(points[3], u2, v1);
     }
 
-    private double[] normalize(double[] vec) {
-        double len = Math.sqrt((vec[0] * vec[0]) + (vec[1] * vec[1]) + (vec[2] * vec[2]));
-        return new double[] { vec[0] / len, vec[1] / len, vec[2] / len };
-    }
-
-    private double[] scale(double[] vec, double scale) {
-        return new double[] { vec[0] * scale, vec[1] * scale, vec[2] * scale };
-    }
-
-    private double[] vectorBetweenPoints(double[] vec1, double[] vec2) {
-        return new double[] { vec1[0] - vec2[0], vec1[1] - vec2[1], vec1[2] - vec2[2] };
-    }
-
-    private void drawScreenWithBorder(byte[] points, byte[] n, double u1, double u2, double v1, double v2,
-            double border, int facing) {
+    private void drawScreenWithBorder(byte[] points, byte[] n, double u1, double u2, double v1, double v2, double border, int facing) {
         final Tessellator tess = Tessellator.instance;
         tess.setNormal(n[0], n[1], n[2]);
-        double[][] UVMap = { { u1, v1 }, { u1, v2 }, { u2, v2 }, { u2, v1 } };
-        byte[] edges = { points[3], points[0], points[1], points[2], points[3], points[0] };
+        double[][] UVMap = {
+            { u1, v1 },
+            { u1, v2 },
+            { u2, v2 },
+            { u2, v1 }
+        };
 
-        for (int i = 1; i < 5; i++) {
-            double[] edge1 = scale(
-                    normalize(
-                            vectorBetweenPoints(
-                                    new double[] { coordinates[edges[i] * 3], coordinates[edges[i] * 3 + 1],
-                                            coordinates[edges[i] * 3 + 2] },
-                                    new double[] { coordinates[edges[i + 1] * 3], coordinates[edges[i + 1] * 3 + 1],
-                                            coordinates[edges[i + 1] * 3 + 2] })),
-                    border);
-            double[] edge2 = scale(
-                    normalize(
-                            vectorBetweenPoints(
-                                    new double[] { coordinates[edges[i] * 3], coordinates[edges[i] * 3 + 1],
-                                            coordinates[edges[i] * 3 + 2] },
-                                    new double[] { coordinates[edges[i - 1] * 3], coordinates[edges[i - 1] * 3 + 1],
-                                            coordinates[edges[i - 1] * 3 + 2] })),
-                    border);
+        double epsilon = 0.015;
 
-            tess.addVertexWithUV(
-                    coordinates[edges[i] * 3] - edge1[0] - edge2[0] + 0.001 * Facing.offsetsXForSide[facing],
-                    coordinates[edges[i] * 3 + 1] - edge1[1] - edge2[1] + 0.001 * Facing.offsetsYForSide[facing],
-                    coordinates[edges[i] * 3 + 2] - edge1[2] - edge2[2] + 0.001 * Facing.offsetsZForSide[facing],
-                    UVMap[i - 1][0],
-                    UVMap[i - 1][1]);
+        double cx = 0.0, cy = 0.0, cz = 0.0;
+
+        for (int i = 0; i < 4; i++) {
+            int idx = points[i] * 3;
+
+            cx += coordinates[idx];
+            cy += coordinates[idx + 1];
+            cz += coordinates[idx + 2];
         }
 
+        cx *= 0.25;
+        cy *= 0.25;
+        cz *= 0.25;
+
+        for (int i = 0; i < 4; i++) {
+            int idx = points[i] * 3;
+
+            double x = coordinates[idx];
+            double y = coordinates[idx + 1];
+            double z = coordinates[idx + 2];
+
+            switch (facing) {
+                case 0: // down (XZ plane)
+                case 1: // up
+                    x += (x > cx ? -border : border);
+                    z += (z > cz ? -border : border);
+                    y += epsilon * n[1];
+                    break;
+
+                case 2: // north (XY plane)
+                case 3: // south
+                    x += (x > cx ? -border : border);
+                    y += (y > cy ? -border : border);
+                    z += epsilon * n[2];
+                    break;
+
+                case 4: // west (ZY plane)
+                case 5: // east
+                    z += (z > cz ? -border : border);
+                    y += (y > cy ? -border : border);
+                    x += epsilon * n[0];
+                    break;
+            }
+
+            tess.addVertexWithUV(x, y, z, UVMap[i][0], UVMap[i][1]);
+        }
     }
 
-    private void drawFacing(int facing, int rotation, Screen screen, TileEntityAdvancedInfoPanel panel, Block block,
-            Tessellator tess) {
-
+    private void drawFacing(int facing, TileEntityAdvancedInfoPanel panel, Block block) {
         IIcon texture = block.getIcon(panel.getWorldObj(), panel.xCoord, panel.yCoord, panel.zCoord, 0);
 
         double u1 = texture.getMinU();
@@ -277,16 +296,12 @@ public class ModelInfoPanel {
         v2 = texture.getMaxV();
 
         drawScreenWithBorder(pointMap[facing], normalMap[facing], u1, u2, v1, v2, 0.05, facing);
-
     }
 
-    public void renderScreen(Block block, TileEntityAdvancedInfoPanel panel, double x, double y, double z,
-            RenderBlocks renderer) {
+    public void renderScreen(Block block) {
         Screen screen = panel.getScreen();
         if (screen == null) return;
-        initCoordinates(block, screen);
-        double[] deltas = getDeltas(panel, screen);
-        addSlopes(panel, screen, deltas);
+        panel.screenModelInfo.recomputeCoordinates(block, screen);
 
         int facing = panel.getFacing();
         Tessellator tess = Tessellator.instance;
@@ -296,7 +311,7 @@ public class ModelInfoPanel {
         tess.setColorOpaque_F(0.5F, 0.5F, 0.5F);
 
         if (panel.getTransparencyMode() == 0) { // Check if face should be transparent
-            drawFacing(facing, panel.getRotation(), screen, panel, block, tess);
+            drawFacing(facing, panel, block);
         }
 
         // SIDES

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ScreenModelInfo.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ScreenModelInfo.java
@@ -1,12 +1,14 @@
 package shedar.mods.ic2.nuclearcontrol.renderers.model;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
+
 import org.lwjgl.opengl.GL11;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
 
@@ -21,7 +23,7 @@ public class ScreenModelInfo {
     private static final double Vmi = advSideTex.getMinV();
 
     private final double[] coordinates = new double[24];
-    private static final byte[][] pointMap = { { 0, 3, 2, 1 }, { 4, 5, 6, 7 }, {        0, 4, 7, 3 }, { 6, 5, 1, 2 },
+    private static final byte[][] pointMap = { { 0, 3, 2, 1 }, { 4, 5, 6, 7 }, { 0, 4, 7, 3 }, { 6, 5, 1, 2 },
             { 5, 4, 0, 1 }, { 2, 3, 7, 6 } };
     private static final byte[][] normalMap = { { 0, -1, 0 }, { 0, 1, 0 }, { 0, 0, -1 }, { 0, 0, 1 }, { -1, 0, 0 },
             { 1, 0, 0 } };
@@ -220,15 +222,11 @@ public class ScreenModelInfo {
         addPoint(points[3], u2, v1);
     }
 
-    private void drawScreenWithBorder(byte[] points, byte[] n, double u1, double u2, double v1, double v2, double border, int facing) {
+    private void drawScreenWithBorder(byte[] points, byte[] n, double u1, double u2, double v1, double v2,
+            double border, int facing) {
         final Tessellator tess = Tessellator.instance;
         tess.setNormal(n[0], n[1], n[2]);
-        double[][] UVMap = {
-            { u1, v1 },
-            { u1, v2 },
-            { u2, v2 },
-            { u2, v1 }
-        };
+        double[][] UVMap = { { u1, v1 }, { u1, v2 }, { u2, v2 }, { u2, v1 } };
 
         double epsilon = 0.015;
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -20,6 +20,7 @@ import shedar.mods.ic2.nuclearcontrol.api.IPanelDataSource;
 import shedar.mods.ic2.nuclearcontrol.api.PanelString;
 import shedar.mods.ic2.nuclearcontrol.items.ItemUpgrade;
 import shedar.mods.ic2.nuclearcontrol.panel.CardWrapperImpl;
+import shedar.mods.ic2.nuclearcontrol.renderers.model.ScreenModelInfo;
 import shedar.mods.ic2.nuclearcontrol.utils.BlockDamages;
 import shedar.mods.ic2.nuclearcontrol.utils.DataSorter;
 import shedar.mods.ic2.nuclearcontrol.utils.NuclearNetworkHelper;
@@ -60,6 +61,8 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     private byte prevRotateHor;
     private byte prevRotateVert;
     private byte prevTextRotation;
+
+    public final ScreenModelInfo screenModelInfo = new ScreenModelInfo(this);
 
     public ItemStack card2;
     public ItemStack card3;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Facing;
 import net.minecraftforge.common.util.Constants;
@@ -101,6 +102,12 @@ public class TileEntityInfoPanel extends TileEntity
     public boolean colored;
 
     private final Map<Integer, List<PanelString>> cardData;
+
+    @Override
+    public AxisAlignedBB getRenderBoundingBox() {
+        Screen screen = getScreen();
+        return screen == null ? super.getRenderBoundingBox() : screen.getBoundingBox();
+    }
 
     @Override
     public short getFacing() {


### PR DESCRIPTION
Same idea as https://github.com/GTNewHorizons/Display-Panels/pull/2

Things to note:
- Does not address allocations caused by poor PanelString instantiating logic, I'll open a different PR containing fixes there
- Minimal testing, LAN + local environment but did not try w/ various panels

Differences from original PR (Display-Panels)
- Doesn't include variable tile entity render distance as with the original PR from Display-Panels
- epsilon increased from 0.01 -> 0.015 due to clipping I found in multiplayer only? This should probably be reconsidered but in my testing this fixed it whilst keeping the screen looking the same