### PR TITLE
Fix line config buttons invisible on auto GUI scale

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/controls/GuiScrollableList.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/controls/GuiScrollableList.java
@@ -9,6 +9,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
+import net.minecraft.client.gui.ScaledResolution;
+
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
@@ -287,7 +289,8 @@ public class GuiScrollableList extends GuiScreen {
      * @param height height
      */
     private void setScissor(int x, int y, int width, int height) {
-        int scaleFactor = mc.gameSettings.guiScale;
+        ScaledResolution scaler = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
+        int scaleFactor = scaler.getScaleFactor();
         GL11.glScissor(
                 x * scaleFactor,
                 (mc.displayHeight - (y + height) * scaleFactor),

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/controls/GuiScrollableList.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/controls/GuiScrollableList.java
@@ -5,11 +5,10 @@ import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
-
-import net.minecraft.client.gui.ScaledResolution;
 
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;


### PR DESCRIPTION
## Summary
- `setScissor()` used `mc.gameSettings.guiScale` directly, which is `0` when "Auto" GUI scale is selected
- Multiplying all scissor coordinates by `0` produced a zero-size scissor rectangle, clipping every toggle button in the line configuration list
- Fixed by using `ScaledResolution.getScaleFactor()` to get the actual resolved scale factor (same pattern already used in `GuiHowlerAlarmListBox`)

Closes GTNewHorizons/GT-New-Horizons-Modpack#23767

## Preview in "Auto" GUI scale
<img width="1918" height="1076" alt="image" src="https://github.com/user-attachments/assets/c332089b-e123-4d29-8996-bd7d3b6e5969" />
