### PR TITLE
remove render allocations in the panels

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/controls/GuiScrollableList.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/gui/controls/GuiScrollableList.java
@@ -368,6 +368,7 @@ public class GuiScrollableList extends GuiScreen {
             draggedButton = null;
             updateVisibleButtons();
             newDataSorter.computeSortOrder(originalButtonList, buttonListFull);
+            panel.resetCardData();
             dataSorterChanged = true;
             // check if the scrollbar is being used
         } else if (scrollbarOffset != -1) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/CardWrapperImpl.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/CardWrapperImpl.java
@@ -29,7 +29,6 @@ public class CardWrapperImpl implements ICardWrapper {
         }
         this.card = card;
         this.slot = (byte) slot;
-        updateSet = new HashMap<>();
     }
 
     @Override
@@ -63,9 +62,9 @@ public class CardWrapperImpl implements ICardWrapper {
         NBTTagCompound nbtTagCompound = ItemStackUtils.getTagCompound(card);
         if (nbtTagCompound.hasKey(name)) {
             Integer prevValue = nbtTagCompound.getInteger(name);
-            if (prevValue == null || !prevValue.equals(value)) updateSet.put(name, value);
+            if (prevValue == null || !prevValue.equals(value)) getUpdateSet().put(name, value);
         } else {
-            updateSet.put(name, value);
+            getUpdateSet().put(name, value);
         }
         nbtTagCompound.setInteger(name, value);
     }
@@ -85,10 +84,10 @@ public class CardWrapperImpl implements ICardWrapper {
         if (nbtTagCompound.hasKey(name)) {
             Long prevValue = nbtTagCompound.getLong(name);
             if (prevValue == null || !prevValue.equals(value)) {
-                updateSet.put(name, value);
+                getUpdateSet().put(name, value);
             }
         } else {
-            updateSet.put(name, value);
+            getUpdateSet().put(name, value);
         }
         nbtTagCompound.setLong(name, value);
     }
@@ -107,9 +106,9 @@ public class CardWrapperImpl implements ICardWrapper {
         NBTTagCompound nbtTagCompound = ItemStackUtils.getTagCompound(card);
         if (nbtTagCompound.hasKey(name)) {
             Double prevValue = nbtTagCompound.getDouble(name);
-            if (prevValue == null || prevValue != value) updateSet.put(name, value);
+            if (prevValue == null || prevValue != value) getUpdateSet().put(name, value);
         } else {
-            updateSet.put(name, value);
+            getUpdateSet().put(name, value);
         }
         nbtTagCompound.setDouble(name, value);
     }
@@ -131,9 +130,9 @@ public class CardWrapperImpl implements ICardWrapper {
         NBTTagCompound nbtTagCompound = ItemStackUtils.getTagCompound(card);
         if (nbtTagCompound.hasKey(name)) {
             String prevValue = nbtTagCompound.getString(name);
-            if (prevValue == null || !prevValue.equals(value)) updateSet.put(name, value);
+            if (prevValue == null || !prevValue.equals(value)) getUpdateSet().put(name, value);
         } else {
-            updateSet.put(name, value);
+            getUpdateSet().put(name, value);
         }
         nbtTagCompound.setString(name, value);
     }
@@ -152,9 +151,9 @@ public class CardWrapperImpl implements ICardWrapper {
         NBTTagCompound nbtTagCompound = ItemStackUtils.getTagCompound(card);
         if (nbtTagCompound.hasKey(name)) {
             Boolean prevValue = nbtTagCompound.getBoolean(name);
-            if (prevValue == null || !prevValue.equals(value)) updateSet.put(name, value);
+            if (prevValue == null || !prevValue.equals(value)) getUpdateSet().put(name, value);
         } else {
-            updateSet.put(name, value);
+            getUpdateSet().put(name, value);
         }
         nbtTagCompound.setBoolean(name, value);
     }
@@ -200,7 +199,7 @@ public class CardWrapperImpl implements ICardWrapper {
 
     @Override
     public void commit(TileEntity panel) {
-        if (!updateSet.isEmpty()) {
+        if (updateSet != null && !updateSet.isEmpty()) {
             NuclearNetworkHelper.setSensorCardField(panel, slot, updateSet);
         }
     }
@@ -210,9 +209,9 @@ public class CardWrapperImpl implements ICardWrapper {
         NBTTagCompound nbtTagCompound = ItemStackUtils.getTagCompound(card);
         if (nbtTagCompound.hasKey(name)) {
             NBTBase prevValue = nbtTagCompound.getTag(name);
-            if (prevValue == null || !prevValue.equals(value)) updateSet.put(name, value);
+            if (prevValue == null || !prevValue.equals(value)) getUpdateSet().put(name, value);
         } else {
-            updateSet.put(name, value);
+            getUpdateSet().put(name, value);
         }
         if (value == null) {
             nbtTagCompound.removeTag(name);
@@ -236,6 +235,9 @@ public class CardWrapperImpl implements ICardWrapper {
     }
 
     public Map<String, Object> getUpdateSet() {
+        if (updateSet == null) {
+            updateSet = new HashMap<>();
+        }
         return this.updateSet;
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
@@ -1,5 +1,6 @@
 package shedar.mods.ic2.nuclearcontrol.renderers;
 
+import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
 
 import net.minecraft.block.Block;
@@ -33,27 +34,25 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
      * Advanced screens only draw their box from the core's chunk. When the core leaves the view frustum the box
      * disappears even though the extenders are still visible. An extender whose chunk is visible then draws the box
      * instead. The box geometry is identical to the core's, so overlapping copies resolve cleanly in the depth buffer.
+     *
+     * <p>
+     * Values are weakly held so an unloaded world cannot keep a fallback alive. The box is baked into chunk display
+     * lists, so the chunk holding the previous source is always rebuilt when the source is replaced or removed.
      */
-    private static final WeakHashMap<TileEntityAdvancedInfoPanel, TileEntityAdvancedInfoPanelExtender> SCREEN_BOX_SOURCES = new WeakHashMap<>();
+    private static final WeakHashMap<TileEntityAdvancedInfoPanel, WeakReference<TileEntityAdvancedInfoPanelExtender>> SCREEN_BOX_SOURCES = new WeakHashMap<>();
 
-    private static boolean isChunkInFrustum(int x, int y, int z) {
-        Frustrum frustrum = new Frustrum();
-        frustrum.setPosition(
-                RenderManager.instance.renderPosX,
-                RenderManager.instance.renderPosY,
-                RenderManager.instance.renderPosZ);
-        int cx = x >> 4;
-        int cy = y >> 4;
-        int cz = z >> 4;
-        return frustrum.isBoxInFrustum(cx * 16, cy * 16, cz * 16, cx * 16 + 16, cy * 16 + 16, cz * 16 + 16);
+    private static final Frustrum FRUSTRUM = new Frustrum();
+
+    private static TileEntityAdvancedInfoPanelExtender getBoxSource(TileEntityAdvancedInfoPanel core) {
+        WeakReference<TileEntityAdvancedInfoPanelExtender> ref = SCREEN_BOX_SOURCES.get(core);
+        TileEntityAdvancedInfoPanelExtender source = ref == null ? null : ref.get();
+        if (ref != null && source == null) {
+            SCREEN_BOX_SOURCES.remove(core);
+        }
+        return source;
     }
 
-    public static void updateScreenBoxFallback(TileEntityAdvancedInfoPanel core,
-            TileEntityAdvancedInfoPanelExtender extender, World world) {
-        if (isChunkInFrustum(core.xCoord, core.yCoord, core.zCoord)) return;
-        TileEntityAdvancedInfoPanelExtender source = SCREEN_BOX_SOURCES.get(core);
-        if (source != null && isChunkInFrustum(source.xCoord, source.yCoord, source.zCoord)) return;
-        SCREEN_BOX_SOURCES.put(core, extender);
+    private static void markBoxSourceRange(TileEntityAdvancedInfoPanelExtender extender, World world) {
         world.markBlockRangeForRenderUpdate(
                 extender.xCoord - 1,
                 extender.yCoord - 1,
@@ -61,6 +60,35 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
                 extender.xCoord + 1,
                 extender.yCoord + 1,
                 extender.zCoord + 1);
+    }
+
+    private static boolean isChunkInFrustum(int x, int y, int z) {
+        FRUSTRUM.setPosition(
+                RenderManager.instance.renderPosX,
+                RenderManager.instance.renderPosY,
+                RenderManager.instance.renderPosZ);
+        int cx = x >> 4;
+        int cy = y >> 4;
+        int cz = z >> 4;
+        return FRUSTRUM.isBoxInFrustum(cx * 16, cy * 16, cz * 16, cx * 16 + 16, cy * 16 + 16, cz * 16 + 16);
+    }
+
+    public static void updateScreenBoxFallback(TileEntityAdvancedInfoPanel core,
+            TileEntityAdvancedInfoPanelExtender extender, World world) {
+        TileEntityAdvancedInfoPanelExtender source = getBoxSource(core);
+        if (isChunkInFrustum(core.xCoord, core.yCoord, core.zCoord)) {
+            if (source != null) {
+                SCREEN_BOX_SOURCES.remove(core);
+                markBoxSourceRange(source, world);
+            }
+            return;
+        }
+        if (source != null && isChunkInFrustum(source.xCoord, source.yCoord, source.zCoord)) return;
+        if (source != null && source != extender) {
+            markBoxSourceRange(source, world);
+        }
+        SCREEN_BOX_SOURCES.put(core, new WeakReference<TileEntityAdvancedInfoPanelExtender>(extender));
+        markBoxSourceRange(extender, world);
     }
 
     public MainBlockRenderer(int modelId) {
@@ -147,7 +175,7 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
                     Screen screen = advancedExtender.getScreen();
                     TileEntity core = screen == null ? null : screen.getCore(advancedExtender.getWorldObj());
                     if (core instanceof TileEntityAdvancedInfoPanel
-                            && SCREEN_BOX_SOURCES.get(core) == advancedExtender) {
+                            && getBoxSource((TileEntityAdvancedInfoPanel) core) == advancedExtender) {
                         new ModelInfoPanel().renderScreen(block, (TileEntityAdvancedInfoPanel) core, x, y, z, renderer);
                     }
                 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
@@ -141,23 +141,7 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
 
             } else if (tileEntity instanceof TileEntityAdvancedInfoPanelExtender) {
                 TileEntityAdvancedInfoPanelExtender advancedExtender = (TileEntityAdvancedInfoPanelExtender) tileEntity;
-                boolean wasRendered = false;
-
-                if (IC2NuclearControl.instance.screenManager == null
-                        || IC2NuclearControl.instance.screenManager.getScreens().get(
-                                IC2NuclearControl.instance.screenManager.getWorldKey(advancedExtender.getWorldObj()))
-                                == null) {
-                    wasRendered = true;
-                } else {
-                    for (Screen screen : IC2NuclearControl.instance.screenManager.getScreens().get(
-                            IC2NuclearControl.instance.screenManager.getWorldKey(advancedExtender.getWorldObj()))) {
-                        if (screen != null && screen.isBlockPartOf(advancedExtender)) {
-                            wasRendered = true;
-                        }
-                    }
-                }
-
-                if (!wasRendered) {
+                if (advancedExtender.getScreen() == null) {
                     renderer.renderStandardBlock(block, x, y, z);
                 } else {
                     Screen screen = advancedExtender.getScreen();

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/MainBlockRenderer.java
@@ -1,10 +1,15 @@
 package shedar.mods.ic2.nuclearcontrol.renderers;
 
+import java.util.WeakHashMap;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.culling.Frustrum;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import org.lwjgl.opengl.GL11;
 
@@ -23,6 +28,40 @@ import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanelEx
 public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
 
     private int modelId;
+
+    /**
+     * Advanced screens only draw their box from the core's chunk. When the core leaves the view frustum the box
+     * disappears even though the extenders are still visible. An extender whose chunk is visible then draws the box
+     * instead. The box geometry is identical to the core's, so overlapping copies resolve cleanly in the depth buffer.
+     */
+    private static final WeakHashMap<TileEntityAdvancedInfoPanel, TileEntityAdvancedInfoPanelExtender> SCREEN_BOX_SOURCES = new WeakHashMap<>();
+
+    private static boolean isChunkInFrustum(int x, int y, int z) {
+        Frustrum frustrum = new Frustrum();
+        frustrum.setPosition(
+                RenderManager.instance.renderPosX,
+                RenderManager.instance.renderPosY,
+                RenderManager.instance.renderPosZ);
+        int cx = x >> 4;
+        int cy = y >> 4;
+        int cz = z >> 4;
+        return frustrum.isBoxInFrustum(cx * 16, cy * 16, cz * 16, cx * 16 + 16, cy * 16 + 16, cz * 16 + 16);
+    }
+
+    public static void updateScreenBoxFallback(TileEntityAdvancedInfoPanel core,
+            TileEntityAdvancedInfoPanelExtender extender, World world) {
+        if (isChunkInFrustum(core.xCoord, core.yCoord, core.zCoord)) return;
+        TileEntityAdvancedInfoPanelExtender source = SCREEN_BOX_SOURCES.get(core);
+        if (source != null && isChunkInFrustum(source.xCoord, source.yCoord, source.zCoord)) return;
+        SCREEN_BOX_SOURCES.put(core, extender);
+        world.markBlockRangeForRenderUpdate(
+                extender.xCoord - 1,
+                extender.yCoord - 1,
+                extender.zCoord - 1,
+                extender.xCoord + 1,
+                extender.yCoord + 1,
+                extender.zCoord + 1);
+    }
 
     public MainBlockRenderer(int modelId) {
         this.modelId = modelId;
@@ -120,6 +159,13 @@ public class MainBlockRenderer implements ISimpleBlockRenderingHandler {
 
                 if (!wasRendered) {
                     renderer.renderStandardBlock(block, x, y, z);
+                } else {
+                    Screen screen = advancedExtender.getScreen();
+                    TileEntity core = screen == null ? null : screen.getCore(advancedExtender.getWorldObj());
+                    if (core instanceof TileEntityAdvancedInfoPanel
+                            && SCREEN_BOX_SOURCES.get(core) == advancedExtender) {
+                        new ModelInfoPanel().renderScreen(block, (TileEntityAdvancedInfoPanel) core, x, y, z, renderer);
+                    }
                 }
 
             } else {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -30,19 +30,18 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
     private static final ModelInfoPanel MODEL = new ModelInfoPanel();
     private final double[] deltasBuffer = new double[4];
 
-    private static String implodeArray(String[] inputArray, String glueString) {
-        String output = "";
-        if (inputArray.length > 0) {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < inputArray.length; i++) {
-                if (inputArray[i] == null || inputArray[i].isEmpty()) continue;
-                sb.append(glueString);
-                sb.append(inputArray[i]);
-            }
-            output = sb.toString();
-            if (output.length() > 1) output = output.substring(1);
-        }
-        return output;
+    private static String joinText(String left, String center, String right) {
+        StringBuilder sb = new StringBuilder();
+        appendPart(sb, left);
+        appendPart(sb, center);
+        appendPart(sb, right);
+        return sb.toString();
+    }
+
+    private static void appendPart(StringBuilder sb, String part) {
+        if (part == null || part.isEmpty()) return;
+        if (sb.length() > 0) sb.append(' ');
+        sb.append(part);
     }
 
     @Override
@@ -234,9 +233,7 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
             int maxWidth = 1;
             for (PanelString panelString : joinedData) {
-                String currentString = implodeArray(
-                        new String[] { panelString.textLeft, panelString.textCenter, panelString.textRight },
-                        " ");
+                String currentString = joinText(panelString.textLeft, panelString.textCenter, panelString.textRight);
                 maxWidth = Math.max(fontRenderer.getStringWidth(currentString), maxWidth);
             }
             maxWidth += 4;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -1,29 +1,22 @@
 package shedar.mods.ic2.nuclearcontrol.renderers;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Facing;
 
 import org.lwjgl.opengl.GL11;
 
 import shedar.mods.ic2.nuclearcontrol.IScreenPart;
-import shedar.mods.ic2.nuclearcontrol.api.CardState;
-import shedar.mods.ic2.nuclearcontrol.api.DisplaySettingHelper;
-import shedar.mods.ic2.nuclearcontrol.api.IPanelDataSource;
 import shedar.mods.ic2.nuclearcontrol.api.PanelString;
-import shedar.mods.ic2.nuclearcontrol.panel.CardWrapperImpl;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
 import shedar.mods.ic2.nuclearcontrol.renderers.model.ModelInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityInfoPanel;
-import shedar.mods.ic2.nuclearcontrol.utils.StringUtils;
 
 public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
@@ -52,33 +45,8 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             if (!panel.getPowered()) {
                 return;
             }
-            boolean anyCardFound = false;
-            List<PanelString> joinedData = new ArrayList<PanelString>();
-            for (int slot = 0; slot < panel.getCardSlotsCount(); slot++) {
-                ItemStack card = panel.getStackInSlot(slot);
-                if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
-                    continue;
-                }
-                CardWrapperImpl helper = new CardWrapperImpl(card, -1);
-                DisplaySettingHelper displaySettings = panel.getNewDisplaySettingsByCard(card, helper);
-                CardState state = helper.getState();
-                List<PanelString> data;
-                if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {
-                    data = StringUtils.getStateMessage(state);
-                } else {
-                    if (panel instanceof TileEntityAdvancedInfoPanel) {
-                        data = ((TileEntityAdvancedInfoPanel) panel).getSortedCardData(displaySettings, card, helper);
-                    } else {
-                        data = panel.getCardData(displaySettings, card, helper);
-                    }
-                }
-                if (data == null) {
-                    continue;
-                }
-                joinedData.addAll(data);
-                anyCardFound = true;
-            }
-            if (!anyCardFound) {
+            List<PanelString> joinedData = panel.getJoinedData();
+            if (joinedData == null) {
                 return;
             }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -15,6 +15,7 @@ import shedar.mods.ic2.nuclearcontrol.api.PanelString;
 import shedar.mods.ic2.nuclearcontrol.panel.Screen;
 import shedar.mods.ic2.nuclearcontrol.renderers.model.ModelInfoPanel;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
+import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanelExtender;
 import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityInfoPanel;
 
 public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
@@ -80,6 +81,19 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
     @Override
     public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float f) {
+        if (tileEntity instanceof TileEntityAdvancedInfoPanelExtender) {
+            TileEntityAdvancedInfoPanelExtender extender = (TileEntityAdvancedInfoPanelExtender) tileEntity;
+            Screen scr = extender.getScreen();
+            if (scr != null) {
+                TileEntity core = scr.getCore(tileEntity.getWorldObj());
+                if (core instanceof TileEntityAdvancedInfoPanel) {
+                    MainBlockRenderer.updateScreenBoxFallback(
+                            (TileEntityAdvancedInfoPanel) core,
+                            extender,
+                            tileEntity.getWorldObj());
+                }
+            }
+        }
         boolean isPanel = tileEntity instanceof TileEntityInfoPanel;
         if (!isPanel && tileEntity instanceof IScreenPart) {
             Screen scr = ((IScreenPart) tileEntity).getScreen();

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -1,6 +1,7 @@
 package shedar.mods.ic2.nuclearcontrol.renderers;
 
 import java.util.List;
+import java.util.WeakHashMap;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.gui.FontRenderer;
@@ -22,6 +23,62 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
     private static final ModelInfoPanel MODEL = new ModelInfoPanel();
     private final double[] deltasBuffer = new double[4];
+    private final WeakHashMap<TileEntityInfoPanel, PanelMeasurements> measurements = new WeakHashMap<>();
+
+    private static class PanelMeasurements {
+
+        final List<PanelString> source;
+        final FontRenderer font;
+        final int maxWidth;
+        final int[] centerWidths;
+        final int[] rightWidths;
+
+        PanelMeasurements(List<PanelString> source, FontRenderer font, int maxWidth, int[] centerWidths,
+                int[] rightWidths) {
+            this.source = source;
+            this.font = font;
+            this.maxWidth = maxWidth;
+            this.centerWidths = centerWidths;
+            this.rightWidths = rightWidths;
+        }
+    }
+
+    private PanelMeasurements getMeasurements(TileEntityInfoPanel panel, List<PanelString> joinedData,
+            FontRenderer fontRenderer) {
+        PanelMeasurements meas = measurements.get(panel);
+        if (meas == null || meas.source != joinedData || meas.font != fontRenderer) {
+            int maxWidth = 1;
+            int spaceWidth = fontRenderer.getStringWidth(" ");
+            int[] centerWidths = new int[joinedData.size()];
+            int[] rightWidths = new int[joinedData.size()];
+            int i = 0;
+            for (PanelString panelString : joinedData) {
+                int lineWidth = 0;
+                int parts = 0;
+                if (panelString.textLeft != null && !panelString.textLeft.isEmpty()) {
+                    lineWidth += fontRenderer.getStringWidth(panelString.textLeft);
+                    parts++;
+                }
+                if (panelString.textCenter != null && !panelString.textCenter.isEmpty()) {
+                    centerWidths[i] = fontRenderer.getStringWidth(panelString.textCenter);
+                    lineWidth += centerWidths[i];
+                    parts++;
+                }
+                if (panelString.textRight != null && !panelString.textRight.isEmpty()) {
+                    rightWidths[i] = fontRenderer.getStringWidth(panelString.textRight);
+                    lineWidth += rightWidths[i];
+                    parts++;
+                }
+                if (parts > 1) lineWidth += (parts - 1) * spaceWidth;
+                maxWidth = Math.max(lineWidth, maxWidth);
+                i++;
+            }
+            maxWidth += 4;
+            meas = new PanelMeasurements(joinedData, fontRenderer, maxWidth, centerWidths, rightWidths);
+            measurements.put(panel, meas);
+        }
+        return meas;
+    }
 
     @Override
     public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float f) {
@@ -185,33 +242,8 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             GL11.glRotatef((float) panel.getTextRotation() * 90.0f, 0, 0, 1);
             FontRenderer fontRenderer = this.func_147498_b();
 
-            int maxWidth = 1;
-            int spaceWidth = fontRenderer.getStringWidth(" ");
-            int[] centerWidths = new int[joinedData.size()];
-            int[] rightWidths = new int[joinedData.size()];
-            int i = 0;
-            for (PanelString panelString : joinedData) {
-                int lineWidth = 0;
-                int parts = 0;
-                if (panelString.textLeft != null && !panelString.textLeft.isEmpty()) {
-                    lineWidth += fontRenderer.getStringWidth(panelString.textLeft);
-                    parts++;
-                }
-                if (panelString.textCenter != null && !panelString.textCenter.isEmpty()) {
-                    centerWidths[i] = fontRenderer.getStringWidth(panelString.textCenter);
-                    lineWidth += centerWidths[i];
-                    parts++;
-                }
-                if (panelString.textRight != null && !panelString.textRight.isEmpty()) {
-                    rightWidths[i] = fontRenderer.getStringWidth(panelString.textRight);
-                    lineWidth += rightWidths[i];
-                    parts++;
-                }
-                if (parts > 1) lineWidth += (parts - 1) * spaceWidth;
-                maxWidth = Math.max(lineWidth, maxWidth);
-                i++;
-            }
-            maxWidth += 4;
+            PanelMeasurements meas = getMeasurements(panel, joinedData, fontRenderer);
+            int maxWidth = meas.maxWidth;
 
             int lineHeight = fontRenderer.FONT_HEIGHT + 2;
             int requiredHeight = lineHeight * joinedData.size();
@@ -257,14 +289,14 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
                 if (panelString.textCenter != null) {
                     fontRenderer.drawString(
                             panelString.textCenter,
-                            -centerWidths[row] / 2,
+                            -meas.centerWidths[row] / 2,
                             offsetY - realHeight / 2 + row * lineHeight,
                             panelString.colorCenter != 0 ? panelString.colorCenter : panel.getColorTextHex());
                 }
                 if (panelString.textRight != null) {
                     fontRenderer.drawString(
                             panelString.textRight,
-                            realWidth / 2 - rightWidths[row],
+                            realWidth / 2 - meas.rightWidths[row],
                             offsetY - realHeight / 2 + row * lineHeight,
                             panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
                 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -3,10 +3,8 @@ package shedar.mods.ic2.nuclearcontrol.renderers;
 import java.util.List;
 import java.util.WeakHashMap;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Facing;
 
@@ -269,10 +267,6 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             } else {
                 offsetX = (realWidth - maxWidth) / 2 + 2;
                 offsetY = 0;
-            }
-            Block block = panel.getWorldObj().getBlock(panel.xCoord, panel.yCoord, panel.zCoord);
-            if (block == null) {
-                block = Blocks.stone;
             }
 
             GL11.glDisable(GL11.GL_LIGHTING);

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -71,9 +71,8 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
                 if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
                     continue;
                 }
-                DisplaySettingHelper displaySettings = panel.getNewDisplaySettingsByCard(card);
-
                 CardWrapperImpl helper = new CardWrapperImpl(card, -1);
+                DisplaySettingHelper displaySettings = panel.getNewDisplaySettingsByCard(card, helper);
                 CardState state = helper.getState();
                 List<PanelString> data;
                 if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -30,20 +30,6 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
     private static final ModelInfoPanel MODEL = new ModelInfoPanel();
     private final double[] deltasBuffer = new double[4];
 
-    private static String joinText(String left, String center, String right) {
-        StringBuilder sb = new StringBuilder();
-        appendPart(sb, left);
-        appendPart(sb, center);
-        appendPart(sb, right);
-        return sb.toString();
-    }
-
-    private static void appendPart(StringBuilder sb, String part) {
-        if (part == null || part.isEmpty()) return;
-        if (sb.length() > 0) sb.append(' ');
-        sb.append(part);
-    }
-
     @Override
     public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float f) {
         boolean isPanel = tileEntity instanceof TileEntityInfoPanel;
@@ -232,9 +218,30 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             FontRenderer fontRenderer = this.func_147498_b();
 
             int maxWidth = 1;
+            int spaceWidth = fontRenderer.getStringWidth(" ");
+            int[] centerWidths = new int[joinedData.size()];
+            int[] rightWidths = new int[joinedData.size()];
+            int i = 0;
             for (PanelString panelString : joinedData) {
-                String currentString = joinText(panelString.textLeft, panelString.textCenter, panelString.textRight);
-                maxWidth = Math.max(fontRenderer.getStringWidth(currentString), maxWidth);
+                int lineWidth = 0;
+                int parts = 0;
+                if (panelString.textLeft != null && !panelString.textLeft.isEmpty()) {
+                    lineWidth += fontRenderer.getStringWidth(panelString.textLeft);
+                    parts++;
+                }
+                if (panelString.textCenter != null && !panelString.textCenter.isEmpty()) {
+                    centerWidths[i] = fontRenderer.getStringWidth(panelString.textCenter);
+                    lineWidth += centerWidths[i];
+                    parts++;
+                }
+                if (panelString.textRight != null && !panelString.textRight.isEmpty()) {
+                    rightWidths[i] = fontRenderer.getStringWidth(panelString.textRight);
+                    lineWidth += rightWidths[i];
+                    parts++;
+                }
+                if (parts > 1) lineWidth += (parts - 1) * spaceWidth;
+                maxWidth = Math.max(lineWidth, maxWidth);
+                i++;
             }
             maxWidth += 4;
 
@@ -282,14 +289,14 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
                 if (panelString.textCenter != null) {
                     fontRenderer.drawString(
                             panelString.textCenter,
-                            -fontRenderer.getStringWidth(panelString.textCenter) / 2,
+                            -centerWidths[row] / 2,
                             offsetY - realHeight / 2 + row * lineHeight,
                             panelString.colorCenter != 0 ? panelString.colorCenter : panel.getColorTextHex());
                 }
                 if (panelString.textRight != null) {
                     fontRenderer.drawString(
                             panelString.textRight,
-                            realWidth / 2 - fontRenderer.getStringWidth(panelString.textRight),
+                            realWidth / 2 - rightWidths[row],
                             offsetY - realHeight / 2 + row * lineHeight,
                             panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
                 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -1,6 +1,6 @@
 package shedar.mods.ic2.nuclearcontrol.renderers;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.block.Block;
@@ -54,7 +54,7 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             }
             List<ItemStack> cards = panel.getCards();
             boolean anyCardFound = false;
-            List<PanelString> joinedData = new LinkedList<PanelString>();
+            List<PanelString> joinedData = new ArrayList<PanelString>();
             for (ItemStack card : cards) {
                 if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
                     continue;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -27,6 +27,9 @@ import shedar.mods.ic2.nuclearcontrol.utils.StringUtils;
 
 public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
+    private static final ModelInfoPanel MODEL = new ModelInfoPanel();
+    private final double[] deltasBuffer = new double[4];
+
     private static String implodeArray(String[] inputArray, String glueString) {
         String output = "";
         if (inputArray.length > 0) {
@@ -177,8 +180,7 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             double[] deltas = null;
             if (panel instanceof TileEntityAdvancedInfoPanel && screen != null) {
                 TileEntityAdvancedInfoPanel advPanel = (TileEntityAdvancedInfoPanel) panel;
-                ModelInfoPanel model = new ModelInfoPanel();
-                deltas = model.getDeltas(advPanel, screen);
+                deltas = MODEL.getDeltas(advPanel, screen, deltasBuffer);
                 thickness = (float) (advPanel.thickness / 16F - (deltas[0] + deltas[1] + deltas[2] + deltas[3]) / 4);
             }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -52,10 +52,10 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             if (!panel.getPowered()) {
                 return;
             }
-            List<ItemStack> cards = panel.getCards();
             boolean anyCardFound = false;
             List<PanelString> joinedData = new ArrayList<PanelString>();
-            for (ItemStack card : cards) {
+            for (int slot = 0; slot < panel.getCardSlotsCount(); slot++) {
+                ItemStack card = panel.getStackInSlot(slot);
                 if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
                     continue;
                 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ModelInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ModelInfoPanel.java
@@ -25,6 +25,7 @@ public class ModelInfoPanel {
     private static final double Vmi = advSideTex.getMinV();
 
     private final double[] coordinates = new double[24];
+    private final double[] deltaBuffer = new double[4];
     private static final byte[][] pointMap = { { 0, 3, 2, 1 }, { 4, 5, 6, 7 }, { 0, 4, 7, 3 }, { 6, 5, 1, 2 },
             { 5, 4, 0, 1 }, { 2, 3, 7, 6 } };
     private static final byte[][] normalMap = { { 0, -1, 0 }, { 0, 1, 0 }, { 0, 0, -1 }, { 0, 0, 1 }, { -1, 0, 0 },
@@ -64,6 +65,10 @@ public class ModelInfoPanel {
     }
 
     public double[] getDeltas(TileEntityAdvancedInfoPanel panel, Screen screen) {
+        return getDeltas(panel, screen, deltaBuffer);
+    }
+
+    public double[] getDeltas(TileEntityAdvancedInfoPanel panel, Screen screen, double[] res) {
         boolean isTopBottom = panel.rotateVert != 0;
         boolean isLeftRight = panel.rotateHor != 0;
         double dTopLeft = 0;
@@ -112,7 +117,10 @@ public class ModelInfoPanel {
             dBottomLeft = scale * dBottomLeft;
             dBottomRight = scale * dBottomRight;
         }
-        double[] res = { dTopLeft, dTopRight, dBottomLeft, dBottomRight };
+        res[0] = dTopLeft;
+        res[1] = dTopRight;
+        res[2] = dBottomLeft;
+        res[3] = dBottomRight;
         return res;
     }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ModelInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/model/ModelInfoPanel.java
@@ -1,7 +1,6 @@
 package shedar.mods.ic2.nuclearcontrol.renderers.model;
 
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.Facing;
@@ -16,13 +15,6 @@ import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityAdvancedInfoPanel;
 
 @SideOnly(Side.CLIENT)
 public class ModelInfoPanel {
-
-    private static final String TEXTURE_FILE = "nuclearcontrol:infoPanel/panelAdvancedSide";
-    private static final IIcon advSideTex = Minecraft.getMinecraft().getTextureMapBlocks().registerIcon(TEXTURE_FILE);
-    private static final double Uma = advSideTex.getMaxU();
-    private static final double Umi = advSideTex.getMinU();
-    private static final double Vma = advSideTex.getMaxV();
-    private static final double Vmi = advSideTex.getMinV();
 
     private final double[] coordinates = new double[24];
     private final double[] deltaBuffer = new double[4];
@@ -309,6 +301,13 @@ public class ModelInfoPanel {
 
         // SIDES
         if (panel.getTransparencyMode() == 0) { // Check if block should be transparent
+
+            IIcon sideIcon = block
+                    .getIcon(panel.getWorldObj(), panel.xCoord, panel.yCoord, panel.zCoord, (facing + 1) % 6);
+            double Umi = sideIcon.getMinU();
+            double Uma = sideIcon.getMaxU();
+            double Vmi = sideIcon.getMinV();
+            double Vma = sideIcon.getMaxV();
 
             tess.setBrightness(
                     block.getMixedBrightnessForBlock(panel.getWorldObj(), panel.xCoord, panel.yCoord, panel.zCoord));

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -67,6 +67,8 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     protected final Map<Byte, Map<UUID, DataSorter>> dataSorters = new HashMap<>();
 
     private final Map<Byte, List<PanelString>> allCardData = new HashMap<>();
+
+    private final Map<Byte, List<PanelString>> sortedCardData = new HashMap<>();
     // </editor-fold>
 
     // <editor-fold desc="Constructor">
@@ -445,6 +447,23 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     public List<PanelString> getSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
             CardWrapperImpl helper) {
         byte slot = getIndexOfCard(cardStack);
+        List<PanelString> sorted = sortedCardData.get(slot);
+        if (sorted == null) {
+            sorted = computeSortedCardData(settings, cardStack, helper);
+            sortedCardData.put(slot, sorted);
+        }
+        return sorted;
+    }
+
+    @Override
+    protected List<PanelString> getCardDataForDisplay(DisplaySettingHelper settings, ItemStack card,
+            CardWrapperImpl helper) {
+        return getSortedCardData(settings, card, helper);
+    }
+
+    private List<PanelString> computeSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
+            CardWrapperImpl helper) {
+        byte slot = getIndexOfCard(cardStack);
         List<PanelString> data = new ArrayList<>(this.getCardData(settings, cardStack, helper));
         List<PanelString> all_data = allCardData.get(slot);
         if (all_data == null) {
@@ -468,6 +487,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     public void resetCardData() {
         super.resetCardData();
         allCardData.clear();
+        sortedCardData.clear();
     }
 
     // </editor-fold>

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -66,7 +66,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
 
     protected final Map<Byte, Map<UUID, DataSorter>> dataSorters = new HashMap<>();
 
-    private final Map<Integer, List<PanelString>> allCardData = new HashMap<>();
+    private final Map<Byte, List<PanelString>> allCardData = new HashMap<>();
     // </editor-fold>
 
     // <editor-fold desc="Constructor">
@@ -444,7 +444,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
      */
     public List<PanelString> getSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
             CardWrapperImpl helper) {
-        int slot = getIndexOfCard(cardStack);
+        byte slot = getIndexOfCard(cardStack);
         List<PanelString> data = new ArrayList<>(this.getCardData(settings, cardStack, helper));
         List<PanelString> all_data = allCardData.get(slot);
         if (all_data == null) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -537,6 +537,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
         if (sendToServer) {
             NuclearNetworkHelper.sendDataSorterSync(this);
         }
+        resetCardData();
     }
     // </editor-fold>
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -65,6 +65,8 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     public ItemStack card3;
 
     protected final Map<Byte, Map<UUID, DataSorter>> dataSorters = new HashMap<>();
+
+    private final Map<Integer, List<PanelString>> allCardData = new HashMap<>();
     // </editor-fold>
 
     // <editor-fold desc="Constructor">
@@ -442,18 +444,30 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
      */
     public List<PanelString> getSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
             CardWrapperImpl helper) {
+        int slot = getIndexOfCard(cardStack);
         List<PanelString> data = new ArrayList<>(this.getCardData(settings, cardStack, helper));
-        List<PanelString> all_data = new ArrayList<>(
-                this.getCardData(new DisplaySettingHelper(true), cardStack, helper));
+        List<PanelString> all_data = allCardData.get(slot);
+        if (all_data == null) {
+            all_data = computeCardData(new DisplaySettingHelper(true), cardStack, helper);
+            if (!Objects.equals(helper.getTitle(), "")) {
+                all_data.remove(0);
+            }
+            allCardData.put(slot, all_data);
+        }
         if (!Objects.equals(helper.getTitle(), "")) {
             PanelString title = data.remove(0);
-            all_data.remove(0);
-            getDataSorter(getIndexOfCard(cardStack)).sortListByPrefix(data, all_data);
+            getDataSorter(slot).sortListByPrefix(data, all_data);
             data.add(0, title);
         } else {
-            getDataSorter(getIndexOfCard(cardStack)).sortListByPrefix(data, all_data);
+            getDataSorter(slot).sortListByPrefix(data, all_data);
         }
         return data;
+    }
+
+    @Override
+    public void resetCardData() {
+        super.resetCardData();
+        allCardData.clear();
     }
 
     // </editor-fold>

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -236,6 +236,7 @@ public class TileEntityInfoPanel extends TileEntity
         if (cardType != null) {
             if (!displaySettings.containsKey(slot)) displaySettings.put(slot, new HashMap<>());
             displaySettings.get(slot).put(cardType, settings);
+            resetCardData();
             if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
                 NuclearNetworkHelper.sendDisplaySettingsUpdate(this, slot, cardType, settings);
             }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -650,6 +650,9 @@ public class TileEntityInfoPanel extends TileEntity
 
     @Override
     public void setInventorySlotContents(int slotNum, ItemStack itemStack) {
+        if (isCardSlot(slotNum) && inventory[slotNum] != itemStack) {
+            resetCardData();
+        }
         inventory[slotNum] = itemStack;
         if (slotNum == SLOT_CARD) {
             setCard(itemStack);

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -908,16 +908,20 @@ public class TileEntityInfoPanel extends TileEntity
     }
 
     public DisplaySettingHelper getNewDisplaySettingsByCard(ItemStack card) {
-        byte slot = getIndexOfCard(card);
         if (card == null) {
             return new DisplaySettingHelper();
         }
+        return getNewDisplaySettingsByCard(card, new CardWrapperImpl(card, 0));
+    }
+
+    public DisplaySettingHelper getNewDisplaySettingsByCard(ItemStack card, CardWrapperImpl helper) {
+        byte slot = getIndexOfCard(card);
         if (!displaySettings.containsKey(slot)) {
             return new DisplaySettingHelper();
         }
         UUID cardType = null;
         if (card.getItem() instanceof IPanelMultiCard) {
-            cardType = ((IPanelMultiCard) card.getItem()).getCardType(new CardWrapperImpl(card, 0));
+            cardType = ((IPanelMultiCard) card.getItem()).getCardType(helper);
         } else if (card.getItem() instanceof IPanelDataSource) {
             cardType = ((IPanelDataSource) card.getItem()).getCardType();
         }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -377,7 +377,6 @@ public class TileEntityInfoPanel extends TileEntity
     public List<PanelString> getCardData(DisplaySettingHelper settings, ItemStack cardStack, ICardWrapper helper) {
         IPanelDataSource card = (IPanelDataSource) cardStack.getItem();
         int slot = getIndexOfCard(cardStack);
-        resetCardData();
         List<PanelString> data = cardData.get(slot);
         if (data == null) {
             if (card != null) data = card.getStringData(settings, helper, getShowLabels());

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -45,6 +45,7 @@ import shedar.mods.ic2.nuclearcontrol.utils.BlockDamages;
 import shedar.mods.ic2.nuclearcontrol.utils.ColorUtil;
 import shedar.mods.ic2.nuclearcontrol.utils.NuclearNetworkHelper;
 import shedar.mods.ic2.nuclearcontrol.utils.RedstoneHelper;
+import shedar.mods.ic2.nuclearcontrol.utils.StringUtils;
 
 public class TileEntityInfoPanel extends TileEntity
         implements ISlotItemFilter, INetworkDataProvider, INetworkUpdateListener, INetworkClientTileEntityEventListener,
@@ -101,6 +102,8 @@ public class TileEntityInfoPanel extends TileEntity
     public boolean colored;
 
     private final Map<Integer, List<PanelString>> cardData;
+
+    private List<PanelString> joinedData;
 
     @Override
     public short getFacing() {
@@ -364,6 +367,43 @@ public class TileEntityInfoPanel extends TileEntity
 
     public void resetCardData() {
         cardData.clear();
+        joinedData = null;
+    }
+
+    /**
+     * get the combined data of all cards in the panel, or null when no card produces data
+     *
+     * @return the combined list of PanelStrings to display
+     */
+    public List<PanelString> getJoinedData() {
+        if (joinedData == null) {
+            joinedData = new ArrayList<>();
+            for (int slot = 0; slot < getCardSlotsCount(); slot++) {
+                ItemStack card = getStackInSlot(slot);
+                if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
+                    continue;
+                }
+                CardWrapperImpl helper = new CardWrapperImpl(card, -1);
+                DisplaySettingHelper displaySettings = getNewDisplaySettingsByCard(card, helper);
+                CardState state = helper.getState();
+                List<PanelString> data;
+                if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {
+                    data = StringUtils.getStateMessage(state);
+                } else {
+                    data = getCardDataForDisplay(displaySettings, card, helper);
+                }
+                if (data == null) {
+                    continue;
+                }
+                joinedData.addAll(data);
+            }
+        }
+        return joinedData.isEmpty() ? null : joinedData;
+    }
+
+    protected List<PanelString> getCardDataForDisplay(DisplaySettingHelper settings, ItemStack card,
+            CardWrapperImpl helper) {
+        return getCardData(settings, card, helper);
     }
 
     /**

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -375,18 +375,25 @@ public class TileEntityInfoPanel extends TileEntity
      * @return a list of PanelStrings to display
      */
     public List<PanelString> getCardData(DisplaySettingHelper settings, ItemStack cardStack, ICardWrapper helper) {
-        IPanelDataSource card = (IPanelDataSource) cardStack.getItem();
         int slot = getIndexOfCard(cardStack);
         List<PanelString> data = cardData.get(slot);
         if (data == null) {
-            if (card != null) data = card.getStringData(settings, helper, getShowLabels());
-            String title = helper.getTitle();
-            if (data != null && title != null && !title.isEmpty()) {
-                PanelString titleString = new PanelString();
-                titleString.textCenter = title;
-                data.add(0, titleString);
-            }
+            data = computeCardData(settings, cardStack, helper);
             cardData.put(slot, data);
+        }
+        return data;
+    }
+
+    protected List<PanelString> computeCardData(DisplaySettingHelper settings, ItemStack cardStack,
+            ICardWrapper helper) {
+        IPanelDataSource card = (IPanelDataSource) cardStack.getItem();
+        List<PanelString> data = null;
+        if (card != null) data = card.getStringData(settings, helper, getShowLabels());
+        String title = helper.getTitle();
+        if (data != null && title != null && !title.isEmpty()) {
+            PanelString titleString = new PanelString();
+            titleString.textCenter = title;
+            data.add(0, titleString);
         }
         return data;
     }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
@@ -15,6 +15,9 @@ public class DataSorter {
 
     private List<Integer> customOrder;
 
+    private Map<String, Integer> prefixOrderCache;
+    private List<PanelString> prefixCacheSource;
+
     /**
      * Default constructor, use only if you don't know the size of the list yet.
      */
@@ -34,6 +37,7 @@ public class DataSorter {
      */
     public void saveCustomOrder(List<Integer> newOrder) {
         this.customOrder = new ArrayList<>(newOrder);
+        this.prefixOrderCache = null;
     }
 
     /**
@@ -45,6 +49,7 @@ public class DataSorter {
         for (int i = 0; i < size; i++) {
             customOrder.add(i);
         }
+        this.prefixOrderCache = null;
     }
 
     /**
@@ -57,6 +62,7 @@ public class DataSorter {
         for (int i = 0; i < size; i++) {
             customOrder.add(i);
         }
+        this.prefixOrderCache = null;
     }
 
     /**
@@ -101,30 +107,44 @@ public class DataSorter {
             this.resetOrder(originalList.size());
         }
 
-        // Build prefix → order map
-        Map<String, Integer> prefixOrderMap = new HashMap<>();
-        for (int i = 0; i < customOrder.size(); i++) {
-            int index = customOrder.get(i);
-            if (index >= 0 && index < originalList.size()) {
-                PanelString item = originalList.get(index);
-                String prefix = getPrefix(item.toString());
-                prefixOrderMap.put(prefix, i);
+        if (prefixOrderCache == null || prefixCacheSource != originalList) {
+            // Build prefix → order map
+            prefixOrderCache = new HashMap<>();
+            for (int i = 0; i < customOrder.size(); i++) {
+                int index = customOrder.get(i);
+                if (index >= 0 && index < originalList.size()) {
+                    PanelString item = originalList.get(index);
+                    prefixOrderCache.put(getPrefix(item.textLeft, item.textCenter, item.textRight), i);
+                }
             }
+            prefixCacheSource = originalList;
         }
 
         // Sort based on prefix order
         data.sort((a, b) -> {
-            int aIndex = prefixOrderMap.getOrDefault(getPrefix(a.toString()), Integer.MAX_VALUE);
-            int bIndex = prefixOrderMap.getOrDefault(getPrefix(b.toString()), Integer.MAX_VALUE);
+            int aIndex = prefixOrderCache.getOrDefault(getPrefix(a.textLeft, a.textCenter, a.textRight),
+                    Integer.MAX_VALUE);
+            int bIndex = prefixOrderCache.getOrDefault(getPrefix(b.textLeft, b.textCenter, b.textRight),
+                    Integer.MAX_VALUE);
             return Integer.compare(aIndex, bIndex);
         });
 
     }
 
     // Helper to extract prefix
-    private String getPrefix(String s) {
-        int colonIndex = s.indexOf(':');
-        return colonIndex == -1 ? s : s.substring(0, colonIndex);
+    private String getPrefix(String left, String center, String right) {
+        int colonIndex = -1;
+        String text = left;
+        if (text == null || text.isEmpty()) {
+            text = center;
+        }
+        if (text == null || text.isEmpty()) {
+            text = right;
+        }
+        if (text != null) {
+            colonIndex = text.indexOf(':');
+        }
+        return colonIndex == -1 ? text : text.substring(0, colonIndex);
     }
 
     /**
@@ -147,6 +167,7 @@ public class DataSorter {
         }
 
         this.customOrder = sortOrder;
+        this.prefixOrderCache = null;
     }
 
     public int[] getArray() {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
@@ -122,10 +122,10 @@ public class DataSorter {
 
         // Sort based on prefix order
         data.sort((a, b) -> {
-            int aIndex = prefixOrderCache.getOrDefault(getPrefix(a.textLeft, a.textCenter, a.textRight),
-                    Integer.MAX_VALUE);
-            int bIndex = prefixOrderCache.getOrDefault(getPrefix(b.textLeft, b.textCenter, b.textRight),
-                    Integer.MAX_VALUE);
+            int aIndex = prefixOrderCache
+                    .getOrDefault(getPrefix(a.textLeft, a.textCenter, a.textRight), Integer.MAX_VALUE);
+            int bIndex = prefixOrderCache
+                    .getOrDefault(getPrefix(b.textLeft, b.textCenter, b.textRight), Integer.MAX_VALUE);
             return Integer.compare(aIndex, bIndex);
         });
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Basically stop the ram nuke that were the panels.
Bonus in this PR: finally fix the advanced panel extenders being invisible when not attached to a panel.
before:
<img width="1671" height="420" alt="image" src="https://github.com/user-attachments/assets/46befcc1-7455-45ae-aa7f-21096de529b6" />
after:
<img width="1667" height="430" alt="image" src="https://github.com/user-attachments/assets/c2a08103-b9cc-49da-ac43-723c7e3d41a1" />
tested in daily 658

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
