### PR TITLE
Another pass on allocation removal

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.9.53:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
+    compileOnly('com.github.GTNewHorizons:Angelica:2.1.60:dev')
     compileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-911-GTNH:dev") {transitive = false}
     compileOnly("com.github.GTNewHorizons:waila:1.19.22:dev") {transitive = false}
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/api/IPanelDataSource.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/api/IPanelDataSource.java
@@ -77,4 +77,15 @@ public interface IPanelDataSource {
      * Control cards for backward compatibility.
      */
     UUID getCardType();
+
+    /**
+     * Whether the card recomputes its display string on the client every tick. Cards whose data derives from the client
+     * state (e.g. the time card reading the world clock) opt in to a per-tick display refresh instead of relying on
+     * packet-driven cache invalidation alone.
+     *
+     * @return true to refresh the card's display once per tick on the client
+     */
+    default boolean needsPerTickRefresh() {
+        return false;
+    }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemTimeCard.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemTimeCard.java
@@ -42,6 +42,11 @@ public class ItemTimeCard extends ItemCardBase {
     }
 
     @Override
+    public boolean needsPerTickRefresh() {
+        return true;
+    }
+
+    @Override
     public List<PanelString> getStringData(DisplaySettingHelper displaySettings, ICardWrapper card,
             boolean showLabels) {
         List<PanelString> result = new ArrayList<PanelString>(1);

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketDataSorterSync.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketDataSorterSync.java
@@ -54,6 +54,7 @@ public class PacketDataSorterSync implements IMessage, IMessageHandler<PacketDat
                     .getTileEntity(message.x, message.y, message.z);
             if (panel != null) {
                 panel.readDataSortersFromNBT(message.dataSortersTag);
+                panel.resetCardData();
             }
         } else if (ctx.side.isServer()) {
             EntityPlayerMP player = ctx.getServerHandler().playerEntity;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketDispSettingsUpdate.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketDispSettingsUpdate.java
@@ -65,7 +65,7 @@ public class PacketDispSettingsUpdate implements IMessage, IMessageHandler<Packe
         }
         TileEntityInfoPanel panel = (TileEntityInfoPanel) tileEntity;
         panel.getDisplaySettingsForSlot(message.slot).put(new UUID(message.most, message.least), message.value);
-        panel.resetCardData();
+        panel.resetCardData(message.slot);
         return null;
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketSensor.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketSensor.java
@@ -179,7 +179,7 @@ public class PacketSensor implements IMessage, IMessageHandler<PacketSensor, IMe
                 helper.clearField(name);
             }
         }
-        panel.resetCardData();
+        panel.resetCardData(message.slot);
         return null;
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketSensorTitle.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/network/message/PacketSensorTitle.java
@@ -62,7 +62,7 @@ public class PacketSensorTitle implements IMessage, IMessageHandler<PacketSensor
             return null;
         }
         new CardWrapperImpl(itemStack, message.slot).setTitle(message.title);
-        panel.resetCardData();
+        panel.resetCardData(message.slot);
         return null;
     }
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
@@ -32,6 +32,10 @@ public class Screen {
         return core;
     }
 
+    public void clearCachedCore() {
+        cachedCore = null;
+    }
+
     public void setCore(TileEntityInfoPanel core) {
         cachedCore = core;
         coreX = core.xCoord;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/Screen.java
@@ -19,15 +19,21 @@ public class Screen {
     private int coreX;
     private int coreY;
     private int coreZ;
+    private TileEntityInfoPanel cachedCore;
     private boolean powered = false;
 
     public TileEntityInfoPanel getCore(IBlockAccess world) {
-        TileEntity tileEntity = world.getTileEntity(coreX, coreY, coreZ);
-        if (tileEntity == null || !(tileEntity instanceof TileEntityInfoPanel)) return null;
-        return (TileEntityInfoPanel) tileEntity;
+        TileEntityInfoPanel core = cachedCore;
+        if (core == null || core.isInvalid() || core.getWorldObj() != world) {
+            TileEntity tileEntity = world.getTileEntity(coreX, coreY, coreZ);
+            core = tileEntity instanceof TileEntityInfoPanel ? (TileEntityInfoPanel) tileEntity : null;
+            cachedCore = core;
+        }
+        return core;
     }
 
     public void setCore(TileEntityInfoPanel core) {
+        cachedCore = core;
         coreX = core.xCoord;
         coreY = core.yCoord;
         coreZ = core.zCoord;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/AngelicaFontBatcher.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/AngelicaFontBatcher.java
@@ -1,0 +1,37 @@
+package shedar.mods.ic2.nuclearcontrol.renderers;
+
+import net.minecraft.client.gui.FontRenderer;
+
+import com.gtnewhorizons.angelica.client.font.BatchingFontRenderer;
+import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
+
+import cpw.mods.fml.common.Loader;
+
+/**
+ * Bridges the info panel text rendering to the Angelica font batcher when it is installed. Every method is a no-op when
+ * Angelica is not present.
+ */
+public final class AngelicaFontBatcher {
+
+    private static final boolean IS_ANGELICA_LOADED = Loader.isModLoaded("angelica");
+
+    private AngelicaFontBatcher() {}
+
+    public static void beginBatch(FontRenderer fontRenderer) {
+        if (!IS_ANGELICA_LOADED) {
+            return;
+        }
+        getBatcher(fontRenderer).beginBatch();
+    }
+
+    public static void endBatch(FontRenderer fontRenderer) {
+        if (!IS_ANGELICA_LOADED) {
+            return;
+        }
+        getBatcher(fontRenderer).endBatch();
+    }
+
+    private static BatchingFontRenderer getBatcher(FontRenderer fontRenderer) {
+        return ((FontRendererAccessor) fontRenderer).angelica$getBatcher();
+    }
+}

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -284,29 +284,34 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
             GL11.glDisable(GL11.GL_LIGHTING);
 
-            for (int row = 0; row < joinedData.size(); row++) {
-                PanelString panelString = joinedData.get(row);
-                if (panelString.textLeft != null) {
-                    fontRenderer.drawString(
-                            panelString.textLeft,
-                            offsetX - realWidth / 2,
-                            1 + offsetY - realHeight / 2 + row * lineHeight,
-                            panelString.colorLeft != 0 ? panelString.colorLeft : panel.getColorTextHex());
+            AngelicaFontBatcher.beginBatch(fontRenderer);
+            try {
+                for (int row = 0; row < joinedData.size(); row++) {
+                    PanelString panelString = joinedData.get(row);
+                    if (panelString.textLeft != null && !panelString.textLeft.isEmpty()) {
+                        fontRenderer.drawString(
+                                panelString.textLeft,
+                                offsetX - realWidth / 2,
+                                1 + offsetY - realHeight / 2 + row * lineHeight,
+                                panelString.colorLeft != 0 ? panelString.colorLeft : panel.getColorTextHex());
+                    }
+                    if (panelString.textCenter != null && !panelString.textCenter.isEmpty()) {
+                        fontRenderer.drawString(
+                                panelString.textCenter,
+                                -meas.centerWidths[row] / 2,
+                                offsetY - realHeight / 2 + row * lineHeight,
+                                panelString.colorCenter != 0 ? panelString.colorCenter : panel.getColorTextHex());
+                    }
+                    if (panelString.textRight != null && !panelString.textRight.isEmpty()) {
+                        fontRenderer.drawString(
+                                panelString.textRight,
+                                realWidth / 2 - meas.rightWidths[row],
+                                offsetY - realHeight / 2 + row * lineHeight,
+                                panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
+                    }
                 }
-                if (panelString.textCenter != null) {
-                    fontRenderer.drawString(
-                            panelString.textCenter,
-                            -meas.centerWidths[row] / 2,
-                            offsetY - realHeight / 2 + row * lineHeight,
-                            panelString.colorCenter != 0 ? panelString.colorCenter : panel.getColorTextHex());
-                }
-                if (panelString.textRight != null) {
-                    fontRenderer.drawString(
-                            panelString.textRight,
-                            realWidth / 2 - meas.rightWidths[row],
-                            offsetY - realHeight / 2 + row * lineHeight,
-                            panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
-                }
+            } finally {
+                AngelicaFontBatcher.endBatch(fontRenderer);
             }
 
             GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/renderers/TileEntityInfoPanelRenderer.java
@@ -50,8 +50,8 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
             int spaceWidth = fontRenderer.getStringWidth(" ");
             int[] centerWidths = new int[joinedData.size()];
             int[] rightWidths = new int[joinedData.size()];
-            int i = 0;
-            for (PanelString panelString : joinedData) {
+            for (int i = 0; i < joinedData.size(); i++) {
+                PanelString panelString = joinedData.get(i);
                 int lineWidth = 0;
                 int parts = 0;
                 if (panelString.textLeft != null && !panelString.textLeft.isEmpty()) {
@@ -70,7 +70,6 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
                 }
                 if (parts > 1) lineWidth += (parts - 1) * spaceWidth;
                 maxWidth = Math.max(lineWidth, maxWidth);
-                i++;
             }
             maxWidth += 4;
             meas = new PanelMeasurements(joinedData, fontRenderer, maxWidth, centerWidths, rightWidths);
@@ -285,8 +284,8 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
 
             GL11.glDisable(GL11.GL_LIGHTING);
 
-            int row = 0;
-            for (PanelString panelString : joinedData) {
+            for (int row = 0; row < joinedData.size(); row++) {
+                PanelString panelString = joinedData.get(row);
                 if (panelString.textLeft != null) {
                     fontRenderer.drawString(
                             panelString.textLeft,
@@ -308,7 +307,6 @@ public class TileEntityInfoPanelRenderer extends TileEntitySpecialRenderer {
                             offsetY - realHeight / 2 + row * lineHeight,
                             panelString.colorRight != 0 ? panelString.colorRight : panel.getColorTextHex());
                 }
-                row++;
             }
 
             GL11.glEnable(GL11.GL_LIGHTING);

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -66,9 +66,9 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
 
     protected final Map<Byte, Map<UUID, DataSorter>> dataSorters = new HashMap<>();
 
-    private final Map<Byte, List<PanelString>> allCardData = new HashMap<>();
+    private final ArrayList<PanelString>[] allCardData;
 
-    private final Map<Byte, List<PanelString>> sortedCardData = new HashMap<>();
+    private final ArrayList<PanelString>[] sortedCardData;
     // </editor-fold>
 
     // <editor-fold desc="Constructor">
@@ -76,8 +76,11 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     /**
      * Default constructor for the Advanced Information Panel.
      */
+    @SuppressWarnings("unchecked")
     public TileEntityAdvancedInfoPanel() {
         super(4); // 3 cards + range/web upgrade
+        allCardData = new ArrayList[4];
+        sortedCardData = new ArrayList[4];
         colored = true;
         thickness = 16;
     }
@@ -447,10 +450,10 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     public List<PanelString> getSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
             CardWrapperImpl helper) {
         byte slot = getIndexOfCard(cardStack);
-        List<PanelString> sorted = sortedCardData.get(slot);
+        ArrayList<PanelString> sorted = sortedCardData[slot];
         if (sorted == null) {
-            sorted = computeSortedCardData(settings, cardStack, helper);
-            sortedCardData.put(slot, sorted);
+            sorted = computeSortedCardData(settings, slot, cardStack, helper);
+            sortedCardData[slot] = sorted;
         }
         return sorted;
     }
@@ -461,20 +464,19 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
         return getSortedCardData(settings, card, helper);
     }
 
-    private List<PanelString> computeSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
+    private ArrayList<PanelString> computeSortedCardData(DisplaySettingHelper settings, byte slot, ItemStack cardStack,
             CardWrapperImpl helper) {
-        byte slot = getIndexOfCard(cardStack);
-        List<PanelString> data = new ArrayList<>(this.getCardData(settings, cardStack, helper));
+        ArrayList<PanelString> data = new ArrayList<>(getCardData(settings, slot, cardStack, helper));
         if (!hasCustomSorterOrder(slot)) {
             return data;
         }
-        List<PanelString> all_data = allCardData.get(slot);
+        ArrayList<PanelString> all_data = allCardData[slot];
         if (all_data == null) {
             all_data = computeCardData(new DisplaySettingHelper(true), cardStack, helper);
             if (!Objects.equals(helper.getTitle(), "")) {
                 all_data.remove(0);
             }
-            allCardData.put(slot, all_data);
+            allCardData[slot] = all_data;
         }
         if (!Objects.equals(helper.getTitle(), "")) {
             PanelString title = data.remove(0);
@@ -502,8 +504,17 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     @Override
     public void resetCardData() {
         super.resetCardData();
-        allCardData.clear();
-        sortedCardData.clear();
+        for (int slot = 0; slot < allCardData.length; slot++) {
+            allCardData[slot] = null;
+            sortedCardData[slot] = null;
+        }
+    }
+
+    @Override
+    public void resetCardData(int slot) {
+        super.resetCardData(slot);
+        allCardData[slot] = null;
+        sortedCardData[slot] = null;
     }
 
     // </editor-fold>
@@ -553,7 +564,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
         if (sendToServer) {
             NuclearNetworkHelper.sendDataSorterSync(this);
         }
-        resetCardData();
+        resetCardData(slot);
     }
     // </editor-fold>
 }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -262,8 +262,10 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
         super.onNetworkUpdate(field);
         if (field.equals("card2")) {
             inventory[SLOT_CARD2] = card2;
+            resetCardData(SLOT_CARD2);
         } else if (field.equals("card3")) {
             inventory[SLOT_CARD3] = card3;
+            resetCardData(SLOT_CARD3);
         } else if (field.equals("powerMode") && prevPowerMode != powerMode) {
             if (screen != null) {
                 screen.turnPower(getPowered(), worldObj);
@@ -512,6 +514,9 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
 
     @Override
     public void resetCardData(int slot) {
+        if (slot < 0 || slot >= allCardData.length) {
+            return;
+        }
         super.resetCardData(slot);
         allCardData[slot] = null;
         sortedCardData[slot] = null;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -465,6 +465,9 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
             CardWrapperImpl helper) {
         byte slot = getIndexOfCard(cardStack);
         List<PanelString> data = new ArrayList<>(this.getCardData(settings, cardStack, helper));
+        if (!hasCustomSorterOrder(slot)) {
+            return data;
+        }
         List<PanelString> all_data = allCardData.get(slot);
         if (all_data == null) {
             all_data = computeCardData(new DisplaySettingHelper(true), cardStack, helper);
@@ -481,6 +484,19 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
             getDataSorter(slot).sortListByPrefix(data, all_data);
         }
         return data;
+    }
+
+    private boolean hasCustomSorterOrder(byte slot) {
+        Map<UUID, DataSorter> slotSorters = dataSorters.get(slot);
+        if (slotSorters == null || slotSorters.isEmpty()) {
+            return false;
+        }
+        ItemStack cardStack = getStackInSlot(slot);
+        if (cardStack == null || !(cardStack.getItem() instanceof IPanelDataSource)) {
+            return false;
+        }
+        DataSorter sorter = slotSorters.get(((IPanelDataSource) cardStack.getItem()).getCardType());
+        return sorter != null && sorter.hasCustomOrder();
     }
 
     @Override

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityAdvancedInfoPanel.java
@@ -449,7 +449,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
      * @param helper    Wrapper object, to access field values.
      * @return a list of PanelStrings to display
      */
-    public List<PanelString> getSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
+    public ArrayList<PanelString> getSortedCardData(DisplaySettingHelper settings, ItemStack cardStack,
             CardWrapperImpl helper) {
         byte slot = getIndexOfCard(cardStack);
         ArrayList<PanelString> sorted = sortedCardData[slot];
@@ -461,7 +461,7 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
     }
 
     @Override
-    protected List<PanelString> getCardDataForDisplay(DisplaySettingHelper settings, ItemStack card,
+    protected ArrayList<PanelString> getCardDataForDisplay(DisplaySettingHelper settings, ItemStack card,
             CardWrapperImpl helper) {
         return getSortedCardData(settings, card, helper);
     }
@@ -518,6 +518,12 @@ public class TileEntityAdvancedInfoPanel extends TileEntityInfoPanel {
             return;
         }
         super.resetCardData(slot);
+        allCardData[slot] = null;
+        sortedCardData[slot] = null;
+    }
+
+    @Override
+    protected void invalidateSlotExtra(int slot) {
         allCardData[slot] = null;
         sortedCardData[slot] = null;
     }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -102,6 +102,18 @@ public class TileEntityInfoPanel extends TileEntity
 
     private List<PanelString> joinedData;
 
+    /**
+     * Card slots whose data is recomputed every tick on the client ({@link IPanelDataSource#needsPerTickRefresh()}).
+     * Empty on panels without live cards, so panels with regular cards never pay for the refresh.
+     */
+    private final List<Integer> liveSlots = new ArrayList<>(1);
+
+    /**
+     * Display data of every slot exactly as it appears in {@link #joinedData}. The per-tick refresh of live cards
+     * rebuilds the joined text from these cached lists without touching the other slots.
+     */
+    private ArrayList<PanelString>[] joinedSlotData;
+
     @Override
     public short getFacing() {
         return (short) Facing.oppositeSide[facing];
@@ -309,6 +321,7 @@ public class TileEntityInfoPanel extends TileEntity
         card = null;
         init = false;
         cardData = new ArrayList[inventorySize];
+        joinedSlotData = new ArrayList[inventorySize];
         tickRate = IC2NuclearControl.instance.screenRefreshPeriod;
         updateTicker = tickRate;
         displaySettings = new HashMap<>(1);
@@ -371,8 +384,10 @@ public class TileEntityInfoPanel extends TileEntity
     public void resetCardData() {
         for (int slot = 0; slot < cardData.length; slot++) {
             cardData[slot] = null;
+            joinedSlotData[slot] = null;
         }
         joinedData = null;
+        liveSlots.clear();
     }
 
     /**
@@ -385,11 +400,14 @@ public class TileEntityInfoPanel extends TileEntity
             return;
         }
         cardData[slot] = null;
+        joinedSlotData[slot] = null;
         joinedData = null;
+        // Explicit Integer boxing to avoid resolving removal by index signature
+        liveSlots.remove((Integer) slot);
     }
 
     /**
-     * get the combined data of all cards in the panel, or null when no card produces data
+     * Get the combined data of all cards in the panel, or null when no card produces data.
      *
      * @return the combined list of PanelStrings to display
      */
@@ -397,29 +415,34 @@ public class TileEntityInfoPanel extends TileEntity
         if (joinedData == null) {
             joinedData = new ArrayList<>();
             for (int slot = 0; slot < getCardSlotsCount(); slot++) {
-                ItemStack card = getStackInSlot(slot);
-                if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
-                    continue;
+                joinedSlotData[slot] = buildJoinedSlotData(slot);
+                if (joinedSlotData[slot] != null) {
+                    joinedData.addAll(joinedSlotData[slot]);
                 }
-                CardWrapperImpl helper = new CardWrapperImpl(card, -1);
-                DisplaySettingHelper displaySettings = getNewDisplaySettingsByCard(card, helper);
-                CardState state = helper.getState();
-                List<PanelString> data;
-                if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {
-                    data = StringUtils.getStateMessage(state);
-                } else {
-                    data = getCardDataForDisplay(displaySettings, card, helper);
-                }
-                if (data == null) {
-                    continue;
-                }
-                joinedData.addAll(data);
             }
         }
         return joinedData.isEmpty() ? null : joinedData;
     }
 
-    protected List<PanelString> getCardDataForDisplay(DisplaySettingHelper settings, ItemStack card,
+    /**
+     * Build the display data of a single card slot as it appears in the joined panel text: the state message for broken
+     * cards, the card data otherwise. Returns null when the slot holds no card or produces no data.
+     */
+    protected ArrayList<PanelString> buildJoinedSlotData(int slot) {
+        ItemStack card = getStackInSlot(slot);
+        if (card == null || !(card.getItem() instanceof IPanelDataSource)) {
+            return null;
+        }
+        CardWrapperImpl helper = new CardWrapperImpl(card, -1);
+        DisplaySettingHelper displaySettings = getNewDisplaySettingsByCard(card, helper);
+        CardState state = helper.getState();
+        if (state != CardState.OK && state != CardState.CUSTOM_ERROR) {
+            return new ArrayList<>(StringUtils.getStateMessage(state));
+        }
+        return getCardDataForDisplay(displaySettings, card, helper);
+    }
+
+    protected ArrayList<PanelString> getCardDataForDisplay(DisplaySettingHelper settings, ItemStack card,
             CardWrapperImpl helper) {
         return getCardData(settings, card, helper);
     }
@@ -432,19 +455,30 @@ public class TileEntityInfoPanel extends TileEntity
      * @param helper    Wrapper object, to access field values.
      * @return a list of PanelStrings to display
      */
-    public List<PanelString> getCardData(DisplaySettingHelper settings, ItemStack cardStack, ICardWrapper helper) {
+    public ArrayList<PanelString> getCardData(DisplaySettingHelper settings, ItemStack cardStack, ICardWrapper helper) {
         return getCardData(settings, getIndexOfCard(cardStack), cardStack, helper);
     }
 
-    protected List<PanelString> getCardData(DisplaySettingHelper settings, int slot, ItemStack cardStack,
+    protected ArrayList<PanelString> getCardData(DisplaySettingHelper settings, int slot, ItemStack cardStack,
             ICardWrapper helper) {
         ArrayList<PanelString> data = cardData[slot];
         if (data == null) {
             data = computeCardData(settings, cardStack, helper);
             cardData[slot] = data;
+            if (data != null && cardStack.getItem() instanceof IPanelDataSource card) {
+                if (card.needsPerTickRefresh() && !liveSlots.contains(slot)) {
+                    liveSlots.add(slot);
+                }
+            }
         }
         return data;
     }
+
+    /**
+     * Hook for subclasses to drop additional per-slot caches when a live card is refreshed. Called every tick for
+     * subscribed slots only.
+     */
+    protected void invalidateSlotExtra(int slot) {}
 
     protected ArrayList<PanelString> computeCardData(DisplaySettingHelper settings, ItemStack cardStack,
             ICardWrapper helper) {
@@ -470,12 +504,36 @@ public class TileEntityInfoPanel extends TileEntity
         if (!init) {
             initData();
         }
+        if (worldObj.isRemote && !liveSlots.isEmpty()) {
+            refreshLiveCardData();
+        }
         if (!worldObj.isRemote) {
             if (updateTicker-- > 0) return;
             updateTicker = tickRate;
             markDirty();
         }
         super.updateEntity();
+    }
+
+    /**
+     * Recompute the display data of the subscribed live cards (e.g. the time card, whose string derives from the client
+     * world clock) once per tick, and rebuild the joined panel text from the per-slot caches without touching the other
+     * slots.
+     */
+    private void refreshLiveCardData() {
+        for (int i = 0; i < liveSlots.size(); i++) {
+            int slot = liveSlots.get(i);
+            cardData[slot] = null;
+            joinedSlotData[slot] = null;
+            invalidateSlotExtra(slot);
+            joinedSlotData[slot] = buildJoinedSlotData(slot);
+        }
+        joinedData = new ArrayList<>();
+        for (int slot = 0; slot < joinedSlotData.length; slot++) {
+            if (joinedSlotData[slot] != null) {
+                joinedData.addAll(joinedSlotData[slot]);
+            }
+        }
     }
 
     protected void postReadFromNBT() {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -65,10 +65,7 @@ public class TileEntityInfoPanel extends TileEntity
     private static final byte LOCATION_RANGE = 8;
 
     protected int updateTicker;
-    protected int dataTicker;
     protected int tickRate;
-    protected int dt;
-    protected int updatedataTicker;
     public boolean init;
     public ItemStack inventory[];
     public NBTTagCompound screenData;
@@ -101,7 +98,7 @@ public class TileEntityInfoPanel extends TileEntity
     private boolean prevColored;
     public boolean colored;
 
-    private final Map<Integer, List<PanelString>> cardData;
+    private final ArrayList<PanelString>[] cardData;
 
     private List<PanelString> joinedData;
 
@@ -236,7 +233,7 @@ public class TileEntityInfoPanel extends TileEntity
         if (cardType != null) {
             if (!displaySettings.containsKey(slot)) displaySettings.put(slot, new HashMap<>());
             displaySettings.get(slot).put(cardType, settings);
-            resetCardData();
+            resetCardData(slot);
             if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
                 NuclearNetworkHelper.sendDisplaySettingsUpdate(this, slot, cardType, settings);
             }
@@ -272,6 +269,7 @@ public class TileEntityInfoPanel extends TileEntity
         }
         if (field.equals("card")) {
             inventory[SLOT_CARD] = card;
+            resetCardData(SLOT_CARD);
         }
         if (field.equals("showLabels")) {
             prevShowLabels = showLabels;
@@ -301,18 +299,16 @@ public class TileEntityInfoPanel extends TileEntity
         }
     }
 
+    @SuppressWarnings("unchecked")
     public TileEntityInfoPanel(int inventorySize) {
         super();
         inventory = new ItemStack[inventorySize];
         screen = null;
         card = null;
         init = false;
-        cardData = new HashMap<Integer, List<PanelString>>();
+        cardData = new ArrayList[inventorySize];
         tickRate = IC2NuclearControl.instance.screenRefreshPeriod;
         updateTicker = tickRate;
-        dt = IC2NuclearControl.instance.dataRefreshPeriod;
-        dataTicker = (dt > tickRate) ? tickRate : dt;
-        updatedataTicker = dataTicker;
         displaySettings = new HashMap<>(1);
         displaySettings.put((byte) 0, new HashMap<>());
         powered = false;
@@ -366,8 +362,24 @@ public class TileEntityInfoPanel extends TileEntity
         init = true;
     }
 
+    /**
+     * Drop all cached display data. Only called from events that can affect every card at once, such as applying the
+     * display settings of the whole screen.
+     */
     public void resetCardData() {
-        cardData.clear();
+        for (int slot = 0; slot < cardData.length; slot++) {
+            cardData[slot] = null;
+        }
+        joinedData = null;
+    }
+
+    /**
+     * Drop the cached display data of a single card slot. O(1): the client is invalidated on every event that changes
+     * the card data (value updates, title changes, display settings, card swaps), so the cache never has to be scanned
+     * or compared on the hot path.
+     */
+    public void resetCardData(int slot) {
+        cardData[slot] = null;
         joinedData = null;
     }
 
@@ -416,20 +428,29 @@ public class TileEntityInfoPanel extends TileEntity
      * @return a list of PanelStrings to display
      */
     public List<PanelString> getCardData(DisplaySettingHelper settings, ItemStack cardStack, ICardWrapper helper) {
-        int slot = getIndexOfCard(cardStack);
-        List<PanelString> data = cardData.get(slot);
+        return getCardData(settings, getIndexOfCard(cardStack), cardStack, helper);
+    }
+
+    protected List<PanelString> getCardData(DisplaySettingHelper settings, int slot, ItemStack cardStack,
+            ICardWrapper helper) {
+        ArrayList<PanelString> data = cardData[slot];
         if (data == null) {
             data = computeCardData(settings, cardStack, helper);
-            cardData.put(slot, data);
+            cardData[slot] = data;
         }
         return data;
     }
 
-    protected List<PanelString> computeCardData(DisplaySettingHelper settings, ItemStack cardStack,
+    protected ArrayList<PanelString> computeCardData(DisplaySettingHelper settings, ItemStack cardStack,
             ICardWrapper helper) {
         IPanelDataSource card = (IPanelDataSource) cardStack.getItem();
-        List<PanelString> data = null;
-        if (card != null) data = card.getStringData(settings, helper, getShowLabels());
+        ArrayList<PanelString> data = null;
+        if (card != null) {
+            List<PanelString> strings = card.getStringData(settings, helper, getShowLabels());
+            if (strings != null) {
+                data = new ArrayList<>(strings);
+            }
+        }
         String title = helper.getTitle();
         if (data != null && title != null && !title.isEmpty()) {
             PanelString titleString = new PanelString();
@@ -443,11 +464,6 @@ public class TileEntityInfoPanel extends TileEntity
     public void updateEntity() {
         if (!init) {
             initData();
-        }
-        updatedataTicker--;
-        if (updatedataTicker <= 0) {
-            resetCardData();
-            updatedataTicker = dataTicker;
         }
         if (!worldObj.isRemote) {
             if (updateTicker-- > 0) return;
@@ -651,7 +667,7 @@ public class TileEntityInfoPanel extends TileEntity
     @Override
     public void setInventorySlotContents(int slotNum, ItemStack itemStack) {
         if (isCardSlot(slotNum) && inventory[slotNum] != itemStack) {
-            resetCardData();
+            resetCardData(slotNum);
         }
         inventory[slotNum] = itemStack;
         if (slotNum == SLOT_CARD) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -874,6 +874,13 @@ public class TileEntityInfoPanel extends TileEntity
     }
 
     @Override
+    public void onChunkUnload() {
+        if (screen != null) {
+            screen.clearCachedCore();
+        }
+    }
+
+    @Override
     public void setScreen(Screen screen) {
         this.screen = screen;
     }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanel.java
@@ -206,6 +206,7 @@ public class TileEntityInfoPanel extends TileEntity
     public void setShowLabels(boolean p) {
         showLabels = p;
         if (prevShowLabels != p) {
+            resetCardData();
             IC2.network.get().updateTileEntityField(this, "showLabels");
         }
         prevShowLabels = showLabels;
@@ -272,6 +273,7 @@ public class TileEntityInfoPanel extends TileEntity
             resetCardData(SLOT_CARD);
         }
         if (field.equals("showLabels")) {
+            resetCardData();
             prevShowLabels = showLabels;
         }
         if (field.equals("powered") && prevPowered != powered) {
@@ -379,6 +381,9 @@ public class TileEntityInfoPanel extends TileEntity
      * or compared on the hot path.
      */
     public void resetCardData(int slot) {
+        if (slot < 0 || slot >= cardData.length) {
+            return;
+        }
         cardData[slot] = null;
         joinedData = null;
     }

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanelExtender.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanelExtender.java
@@ -76,11 +76,7 @@ public class TileEntityInfoPanelExtender extends TileEntity
         if (field.equals("facing") && prevFacing != facing) {
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             prevFacing = facing;
-        } else if (field.equals("partOfScreen") || field.equals("coreX")
-                || field.equals("coreY")
-                || field.equals("coreZ")) {
-                    tryResolveScreen();
-                }
+        }
     }
 
     public TileEntityInfoPanelExtender() {
@@ -116,18 +112,16 @@ public class TileEntityInfoPanelExtender extends TileEntity
     }
 
     /**
-     * Resolve and attach the screen of this extender. Runs at init, when the networked fields of the extender arrive,
-     * and as a periodic retry while the core panel chunk has not been loaded yet. Chunk load order is arbitrary and the
-     * client only receives the screen identity (partOfScreen/coreX/coreY/coreZ) through the IC2 field sync, so without
-     * the retry an extender whose chunk loads late would stay unattached forever.
+     * Attach the screen of this extender once its core screen exists. Retried periodically because the client only
+     * learns the screen identity through the IC2 field sync, which is delivered in no particular order and after the
+     * chunk itself.
      */
     private void tryResolveScreen() {
         if (!partOfScreen || screen != null) return;
         TileEntity core = worldObj.getTileEntity(coreX, coreY, coreZ);
-        if (core != null && core instanceof TileEntityInfoPanel) {
-            screen = ((TileEntityInfoPanel) core).getScreen();
-            if (screen != null) screen.init(true, worldObj);
-        }
+        if (!(core instanceof TileEntityInfoPanel)) return;
+        screen = ((TileEntityInfoPanel) core).getScreen();
+        if (screen != null) screen.init(true, worldObj);
     }
 
     public void setCoreCoordinates(int x, int y, int z) {

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanelExtender.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityInfoPanelExtender.java
@@ -27,6 +27,7 @@ public class TileEntityInfoPanelExtender extends TileEntity
         implements INetworkDataProvider, INetworkUpdateListener, IWrenchable, ITextureHelper, IScreenPart, IRotation {
 
     protected boolean init;
+    private int screenRetryTicks = 40;
 
     private Screen screen;
     private short prevFacing;
@@ -75,7 +76,11 @@ public class TileEntityInfoPanelExtender extends TileEntity
         if (field.equals("facing") && prevFacing != facing) {
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
             prevFacing = facing;
-        }
+        } else if (field.equals("partOfScreen") || field.equals("coreX")
+                || field.equals("coreY")
+                || field.equals("coreZ")) {
+                    tryResolveScreen();
+                }
     }
 
     public TileEntityInfoPanelExtender() {
@@ -90,8 +95,12 @@ public class TileEntityInfoPanelExtender extends TileEntity
 
     @Override
     public List<String> getNetworkedFields() {
-        List<String> list = new ArrayList<String>(1);
+        List<String> list = new ArrayList<String>(5);
         list.add("facing");
+        list.add("partOfScreen");
+        list.add("coreX");
+        list.add("coreY");
+        list.add("coreZ");
         return list;
     }
 
@@ -102,14 +111,23 @@ public class TileEntityInfoPanelExtender extends TileEntity
         if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
             IC2.network.get().updateTileEntityField(this, "facing");
         }
-        if (partOfScreen && screen == null) {
-            TileEntity core = worldObj.getTileEntity(coreX, coreY, coreZ);
-            if (core != null && core instanceof TileEntityInfoPanel) {
-                screen = ((TileEntityInfoPanel) core).getScreen();
-                if (screen != null) screen.init(true, worldObj);
-            }
-        }
+        tryResolveScreen();
         init = true;
+    }
+
+    /**
+     * Resolve and attach the screen of this extender. Runs at init, when the networked fields of the extender arrive,
+     * and as a periodic retry while the core panel chunk has not been loaded yet. Chunk load order is arbitrary and the
+     * client only receives the screen identity (partOfScreen/coreX/coreY/coreZ) through the IC2 field sync, so without
+     * the retry an extender whose chunk loads late would stay unattached forever.
+     */
+    private void tryResolveScreen() {
+        if (!partOfScreen || screen != null) return;
+        TileEntity core = worldObj.getTileEntity(coreX, coreY, coreZ);
+        if (core != null && core instanceof TileEntityInfoPanel) {
+            screen = ((TileEntityInfoPanel) core).getScreen();
+            if (screen != null) screen.init(true, worldObj);
+        }
     }
 
     public void setCoreCoordinates(int x, int y, int z) {
@@ -122,6 +140,10 @@ public class TileEntityInfoPanelExtender extends TileEntity
     public void updateEntity() {
         if (!init) {
             initData();
+        }
+        if (partOfScreen && screen == null && --screenRetryTicks <= 0) {
+            screenRetryTicks = 40;
+            tryResolveScreen();
         }
         super.updateEntity();
     }
@@ -195,6 +217,12 @@ public class TileEntityInfoPanelExtender extends TileEntity
                     screen.getCore(worldObj).xCoord,
                     screen.getCore(worldObj).yCoord,
                     screen.getCore(worldObj).zCoord);
+        }
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
+            IC2.network.get().updateTileEntityField(this, "partOfScreen");
+            IC2.network.get().updateTileEntityField(this, "coreX");
+            IC2.network.get().updateTileEntityField(this, "coreY");
+            IC2.network.get().updateTileEntityField(this, "coreZ");
         }
     }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
@@ -31,6 +31,14 @@ public class DataSorter {
     }
 
     /**
+     * Whether the stored order differs from the default identity order. Sorters that were never configured have an
+     * empty order, which is a no-op, so the caller can skip sorting entirely.
+     */
+    public boolean hasCustomOrder() {
+        return !customOrder.isEmpty();
+    }
+
+    /**
      * Save a custom order, and completely overwrite the one currently stored.
      *
      * @param newOrder the new custom order

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/DataSorter.java
@@ -2,6 +2,7 @@ package shedar.mods.ic2.nuclearcontrol.utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -128,15 +129,17 @@ public class DataSorter {
             prefixCacheSource = originalList;
         }
 
-        // Sort based on prefix order
-        data.sort((a, b) -> {
-            int aIndex = prefixOrderCache
-                    .getOrDefault(getPrefix(a.textLeft, a.textCenter, a.textRight), Integer.MAX_VALUE);
-            int bIndex = prefixOrderCache
-                    .getOrDefault(getPrefix(b.textLeft, b.textCenter, b.textRight), Integer.MAX_VALUE);
-            return Integer.compare(aIndex, bIndex);
-        });
-
+        // Compute the custom-order rank of every element once (one prefix extraction per element), then sort
+        // stably by rank. Elements whose prefix is not in the cache rank last (Integer.MAX_VALUE).
+        Map<PanelString, Integer> ranks = new HashMap<>(data.size() * 2);
+        for (PanelString item : data) {
+            ranks.put(
+                    item,
+                    prefixOrderCache.getOrDefault(
+                            getPrefix(item.textLeft, item.textCenter, item.textRight),
+                            Integer.MAX_VALUE));
+        }
+        data.sort(Comparator.comparingInt(ranks::get));
     }
 
     // Helper to extract prefix


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Follow up of https://github.com/GTNewHorizons/Nuclear-Control/pull/47. Tested on daily 658.

Test area:
<img width="1920" height="1017" alt="2026-08-07_06 13 07" src="https://github.com/user-attachments/assets/d79ba851-844f-492a-99d6-45f719e54b6c" />

Before:
<img width="1529" height="321" alt="image" src="https://github.com/user-attachments/assets/27ca62b4-a5d5-485a-a794-8a73f0d33614" />

After:
<img width="1300" height="364" alt="image" src="https://github.com/user-attachments/assets/a75cd3d7-2efb-4b84-a0a8-d5222a87ccd6" />


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
